### PR TITLE
Fix url matching for Violentmonkey and HTTPS

### DIFF
--- a/Script(for browser)( 21.5.21.7).js
+++ b/Script(for browser)( 21.5.21.7).js
@@ -4,7 +4,7 @@
 // @version      21.5.21.7-manga-fix-2-no-cache
 // @description  Correctly sorts OCR results for full manga pages (top-to-bottom, then right-to-left). Decouples overlay and button hide timers. Fixes a syntax error in image selectors. Caching is disabled to always fetch from server.
 // @author       1Selxo 
-// @match        http://127.0.0.1/*
+// @match        *://127.0.0.1*/*
 // @grant        GM_setValue
 // @grant        GM_getValue
 // @grant        GM_addStyle

--- a/script(For mobile browsers(  24.7.24)).js
+++ b/script(For mobile browsers(  24.7.24)).js
@@ -4,7 +4,7 @@
 // @version      24.7.24-final-fix-2
 // @description  Restores the old, reliable scroll-fix logic that is URL-aware, fixing the "no exit" bug and allowing normal scrolling on non-reader pages. Fixes a syntax error in image selectors.
 // @author       1Selxo 
-// @match        http://127.0.0.1/*
+// @match        *://127.0.0.1*/*
 // @grant        GM_setValue
 // @grant        GM_getValue
 // @grant        GM_addStyle


### PR DESCRIPTION
Suwayomi url looks like this: `http://127.0.0.1:4567/manga`
The previous value for `@match` was `http://127.0.0.1/*`, which matches the port number in Tampermonkey but not in Violentmonkey.

I added a wildcard so that it matches the port number for Violentmonkey, and another wildcard to match both HTTP and HTTPS protocols in the URL just in case someone sets up HTTPS for their Suwayomi server.