### PR TITLE
Support for deno compile

### DIFF
--- a/Ocr-Server/server.js
+++ b/Ocr-Server/server.js
@@ -1,14 +1,14 @@
 // server.js - V2.5 with Conditional Authentication
 import express from 'express';
-import Lens from 'chrome-lens-ocr';
-import fs from 'fs';
-import path from 'path';
+import LensCore from 'chrome-lens-ocr/src/core.js';
+import fs from 'node:fs';
+import path from 'node:path';
 import multer from 'multer';
 import fetch from 'node-fetch'; // Required for the auth path
 
 const app = express();
 const port = 3000;
-const lens = new Lens();
+const lens = new LensCore();
 
 const CACHE_FILE_PATH = path.join(process.cwd(), 'ocr-cache.json');
 const upload = multer({ dest: 'uploads/' });


### PR DESCRIPTION
The main reason `deno compile` (and other alternatives) weren't working is because of an issue with the `sharp` library that `chrome-lens-ocr` uses: https://github.com/lovell/sharp/issues/3912

I have no idea how to fix it, but another option is importing `LensCore` instead of `Lens`, since the former does not import `sharp`. The server works when switching to `LensCore` with minimal code changes, and is compatible with both Node and Deno.

Tested on Windows.