### PR TITLE
fix: docker by changing ip from localhost to wildcard

### DIFF
--- a/ocr-server/server.py
+++ b/ocr-server/server.py
@@ -24,7 +24,7 @@ from PIL import Image
 from waitress import serve
 
 # region Config
-IP_ADDRESS = "127.0.0.1"
+IP_ADDRESS = "0.0.0.0"
 PORT = 3000
 CACHE_FILE_PATH = os.path.join(os.getcwd(), "ocr-cache.json")
 UPLOAD_FOLDER = "uploads"


### PR DESCRIPTION
if we use localhost, we can't access the server outside of the docker image