### PR TITLE
Fix UI freezing during local ScreenAI OCR on Windows

### DIFF
--- a/lib/services/mining/screen_ai_ocr.dart
+++ b/lib/services/mining/screen_ai_ocr.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -22,6 +23,38 @@ class ScreenAiOcrResult {
   final int imageHeight;
   final List<OcrTextBlock> blocks;
   final String componentPath;
+}
+
+/// A sequential lock to ensure only one Isolate accesses the native
+/// ScreenAI DLL at any given time.
+class _OcrLock {
+  static Future<void> _last = Future.value();
+
+  static Future<T> synchronized<T>(FutureOr<T> Function() action) {
+    final completer = Completer<T>();
+    _last.then((_) async {
+      try {
+        final result = await action();
+        completer.complete(result);
+      } catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      }
+    });
+    _last = completer.future.catchError((_) {});
+    return completer.future;
+  }
+}
+
+class _ImageDecodeResult {
+  final Uint8List rgbaBytes;
+  final int width;
+  final int height;
+
+  const _ImageDecodeResult({
+    required this.rgbaBytes,
+    required this.width,
+    required this.height,
+  });
 }
 
 class ScreenAiOcrClient {
@@ -45,24 +78,66 @@ class ScreenAiOcrClient {
         'ScreenAI is not installed. Open Chrome once or select Google Lens.',
       );
     }
-    final image = await _prepareImage(imageBytes);
-    final annotation = _ScreenAiBridge.instance.recognize(
-      componentDirectory: component,
-      image: image,
-    );
+
+    // 1. Decode image to RGBA async on the main thread (uses native engine threads)
+    final decodeResult = await _decodeImageRgba(imageBytes);
+
+    // 2. Offload FFI native execution to a background Isolate
+    final result = await _OcrLock.synchronized(() {
+      return Isolate.run(() {
+        final image = _ScreenAiImage(
+          pixels: decodeResult.rgbaBytes, // Pass raw RGBA bytes directly
+          width: decodeResult.width,
+          height: decodeResult.height,
+          originalWidth: decodeResult.width,
+          originalHeight: decodeResult.height,
+        );
+
+        final annotation = _ScreenAiBridge.instance.recognize(
+          componentDirectory: component,
+          image: image,
+        );
+
+        final blocks = _parseVisualAnnotation(
+          annotation,
+          imageWidth: decodeResult.width,
+          imageHeight: decodeResult.height,
+        );
+
+        return (
+          blocks: blocks,
+          imageWidth: decodeResult.width,
+          imageHeight: decodeResult.height,
+        );
+      });
+    });
+
     return ScreenAiOcrResult(
-      imageWidth: image.originalWidth,
-      imageHeight: image.originalHeight,
-      blocks: _parseVisualAnnotation(
-        annotation,
-        imageWidth: image.width,
-        imageHeight: image.height,
-      ),
+      imageWidth: result.imageWidth,
+      imageHeight: result.imageHeight,
+      blocks: result.blocks,
       componentPath: component.path,
     );
   }
 
   void close() {}
+
+  Future<_ImageDecodeResult> _decodeImageRgba(Uint8List bytes) async {
+    final codec = await ui.instantiateImageCodec(bytes);
+    final frame = await codec.getNextFrame();
+    final width = frame.image.width;
+    final height = frame.image.height;
+    final rgba = await frame.image.toByteData(format: ui.ImageByteFormat.rawRgba);
+    frame.image.dispose();
+    codec.dispose();
+    if (rgba == null) throw StateError('Could not decode image for ScreenAI');
+    
+    return _ImageDecodeResult(
+      rgbaBytes: rgba.buffer.asUint8List(),
+      width: width,
+      height: height,
+    );
+  }
 
   static Directory? _findComponentDirectory() {
     final roots = <Directory>[
@@ -165,12 +240,12 @@ class _ScreenAiBridge {
     required _ScreenAiImage image,
   }) {
     final componentPath = componentDirectory.path.toNativeUtf16();
-    final pixels = calloc<Uint8>(image.bgra.length);
+    final pixels = calloc<Uint8>(image.pixels.length);
     final output = calloc<Pointer<Uint8>>();
     final outputLength = calloc<Uint32>();
     final error = calloc<Pointer<Utf8>>();
     try {
-      pixels.asTypedList(image.bgra.length).setAll(0, image.bgra);
+      pixels.asTypedList(image.pixels.length).setAll(0, image.pixels);
       final status = _recognize(
         componentPath,
         pixels,
@@ -207,32 +282,6 @@ class _ScreenAiBridge {
     if (besideExe.existsSync()) return besideExe.path;
     return p.join(Directory.current.path, 'screen_ai_bridge.dll');
   }
-}
-
-Future<_ScreenAiImage> _prepareImage(Uint8List bytes) async {
-  final codec = await ui.instantiateImageCodec(bytes);
-  final frame = await codec.getNextFrame();
-  final width = frame.image.width;
-  final height = frame.image.height;
-  final rgba = await frame.image.toByteData(format: ui.ImageByteFormat.rawRgba);
-  frame.image.dispose();
-  codec.dispose();
-  if (rgba == null) throw StateError('Could not decode image for ScreenAI');
-  final source = rgba.buffer.asUint8List();
-  final bgra = Uint8List(source.length);
-  for (var i = 0; i < source.length; i += 4) {
-    bgra[i] = source[i + 2];
-    bgra[i + 1] = source[i + 1];
-    bgra[i + 2] = source[i];
-    bgra[i + 3] = source[i + 3];
-  }
-  return _ScreenAiImage(
-    bgra: bgra,
-    width: width,
-    height: height,
-    originalWidth: width,
-    originalHeight: height,
-  );
 }
 
 List<OcrTextBlock> _parseVisualAnnotation(
@@ -316,14 +365,14 @@ _NormalizedRect? _readRect(
 
 class _ScreenAiImage {
   const _ScreenAiImage({
-    required this.bgra,
+    required this.pixels,
     required this.width,
     required this.height,
     required this.originalWidth,
     required this.originalHeight,
   });
 
-  final Uint8List bgra;
+  final Uint8List pixels;
   final int width;
   final int height;
   final int originalWidth;

--- a/windows/runner/screen_ai_bridge.cpp
+++ b/windows/runner/screen_ai_bridge.cpp
@@ -216,7 +216,7 @@ void WriteUint8(uint8_t* target, size_t offset, uint8_t value) {
 
 extern "C" __declspec(dllexport) int ScreenAiRecognize(
     const wchar_t* component_dir,
-    const uint8_t* bgra_pixels,
+    const uint8_t* rgba_pixels,
     int32_t width,
     int32_t height,
     uint8_t** output,
@@ -231,7 +231,7 @@ extern "C" __declspec(dllexport) int ScreenAiRecognize(
   if (error) {
     *error = nullptr;
   }
-  if (!output || !output_length || !bgra_pixels || width <= 0 || height <= 0) {
+  if (!output || !output_length || !rgba_pixels || width <= 0 || height <= 0) {
     if (error) {
       *error = CopyCString("Invalid ScreenAI OCR input");
     }
@@ -245,7 +245,14 @@ extern "C" __declspec(dllexport) int ScreenAiRecognize(
   const uint64_t pixel_count =
       static_cast<uint64_t>(width) * static_cast<uint64_t>(height) * 4;
   std::vector<uint8_t> pixels(pixel_count);
-  std::memcpy(pixels.data(), bgra_pixels, pixels.size());
+  
+  // Fast C++ byte swap from RGBA to BGRA
+  for (size_t i = 0; i < pixel_count; i += 4) {
+    pixels[i]     = rgba_pixels[i + 2]; // B
+    pixels[i + 1] = rgba_pixels[i + 1]; // G
+    pixels[i + 2] = rgba_pixels[i];     // R
+    pixels[i + 3] = rgba_pixels[i + 3]; // A
+  }
 
   uint8_t bitmap[56] = {};
   uint8_t pixel_ref[104] = {};


### PR DESCRIPTION
The Problem:
When using the local ScreenAI OCR engine on Windows, the app's UI would freeze/lock up until the OCR process completed. This happened because the synchronous FFI call to the C++ DLL (ScreenAiRecognize), along with a heavy Dart loop for RGBA-to-BGRA byte swapping, were running directly on the main UI thread, blocking the Flutter event loop.

The Solution:
This PR overhauls the ScreenAI OCR pipeline to be completely non-blocking, ensuring smooth UI performance and faster recognition times.
Changes Made

    Asynchronous Native Decoding: Image decoding is now strictly handled via Flutter's ui.instantiateImageCodec, which safely uses native engine threads to extract the RGBA bytes without blocking.

    Isolate Offloading: The heavy Protobuf parsing and synchronous FFI execution have been moved to a background thread using Isolate.run().

    Sequential FFI Locking (_OcrLock): Added a pure-Dart asynchronous lock to ensure that multiple rapid OCR requests (e.g., scrolling fast through pages) don't cause race conditions inside the C++ DLL's shared static variables.

    High-Performance Byte Swapping (C++): Removed the slow Dart for loop used for RGBA to BGRA conversion. The raw RGBA bytes are now passed directly to screen_ai_bridge.cpp, where the byte swap is handled in C++. This allows the C++ compiler to auto-vectorize the loop using SIMD instructions, making the conversion almost instantaneous and saving Dart GC overhead.

Files Changed

    lib/services/mining/screen_ai_ocr.dart - Implemented Isolate.run, _OcrLock, and updated the bridge to pass raw RGBA.

    windows/runner/screen_ai_bridge.cpp - Updated the function signature to accept RGBA and added the native byte-swapping loop.