### PR TITLE
feat(mining): add responsive in-memory image cropping for Anki manga exports

### DIFF
--- a/lib/modules/mining/widgets/hoshi_dictionary_popup.dart
+++ b/lib/modules/mining/widgets/hoshi_dictionary_popup.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:ui' as ui;
 
+import 'package:crop_image/crop_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -444,6 +446,36 @@ class _HoshiDictionaryPopupState extends State<HoshiDictionaryPopup> {
         botToast('Anki export is disabled in Dictionary settings', second: 4);
         return false;
       }
+
+      MiningContext effectiveContext = miningContext;
+      final cropEnabled = await MiningPreferences.getCropImageBeforeMining();
+      
+      // NEW: Only trigger the crop dialog if the media type is explicitly Manga
+      final isManga = effectiveContext.mediaType == MiningMediaType.manga;
+
+      // Intercept image load to crop if preference is enabled AND we are reading manga
+      if (cropEnabled && isManga && effectiveContext.imageBytesLoader != null) {
+        final rawBytes = await effectiveContext.imageBytesLoader!();
+        if (rawBytes != null && rawBytes.isNotEmpty) {
+          if (!mounted) return false;
+
+          final croppedBytes = await _showCropDialog(
+            context: context,
+            imageBytes: rawBytes,
+          );
+
+          if (croppedBytes != null) {
+            // Override the image bytes loader for AnkiCardBuilder
+            effectiveContext = effectiveContext.copyWith(
+              imageBytesLoader: () => croppedBytes,
+            );
+          } else {
+            // User cancelled cropping, abort mining
+            return false;
+          }
+        }
+      }
+
       final dictionaryMedia = await _loadAnkiDictionaryMedia(
         content['dictionaryMedia'],
       );
@@ -456,7 +488,7 @@ class _HoshiDictionaryPopupState extends State<HoshiDictionaryPopup> {
       );
       final draft = await const AnkiCardBuilder().build(
         result: result,
-        context: miningContext,
+        context: effectiveContext, // Use the cropped effectiveContext
         profile: profile,
         renderedContent: content,
         dictionaryMedia: dictionaryMedia,
@@ -1232,4 +1264,358 @@ class _HoshiPopupData {
   const _HoshiPopupData({required this.html});
 
   final String html;
+}
+
+Future<Uint8List?> _showCropDialog({
+  required BuildContext context,
+  required Uint8List imageBytes,
+}) async {
+  final controller = CropController(
+    aspectRatio: null, // Free crop by default
+    defaultCrop: const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9),
+  );
+
+  final theme = Theme.of(context);
+  final colorScheme = theme.colorScheme;
+  final screenSize = MediaQuery.sizeOf(context);
+
+  // Maximize vertical space for portrait manga pages while leaving a small screen margin
+  final double height = (screenSize.height - 48.0).clamp(320.0, 1200.0);
+  final double width = (screenSize.width - 64.0).clamp(320.0, 1100.0);
+
+  return showDialog<Uint8List>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) {
+      _CropAspectMode aspectMode = _CropAspectMode.free;
+      bool cropping = false;
+
+      return StatefulBuilder(
+        builder: (context, setState) {
+          Future<void> handleCrop() async {
+            setState(() => cropping = true);
+            try {
+              final ui.Image bitmap = await controller.croppedBitmap();
+              final byteData =
+                  await bitmap.toByteData(format: ui.ImageByteFormat.png);
+              if (!context.mounted) return;
+              if (byteData != null) {
+                Navigator.pop(context, byteData.buffer.asUint8List());
+              } else {
+                botToast('Could not crop image: empty result', second: 4);
+                setState(() => cropping = false);
+              }
+            } catch (e) {
+              if (!context.mounted) return;
+              botToast('Could not crop image: $e', second: 4);
+              setState(() => cropping = false);
+            }
+          }
+
+          return Dialog(
+            insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            backgroundColor: colorScheme.surface,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: width, maxHeight: height),
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+                child: Column(
+                  mainAxisSize: MainAxisSize.max,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(Icons.crop, color: colorScheme.primary, size: 20),
+                        const SizedBox(width: 8),
+                        Text('Crop Screenshot', style: theme.textTheme.titleMedium),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Expanded(
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: ColoredBox(
+                          color: colorScheme.surfaceContainerHighest,
+                          child: CropImage(
+                            controller: controller,
+                            image: Image.memory(imageBytes),
+                            paddingSize: 8.0,
+                            alwaysMove: true,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        _CropToolGroup(
+                          colorScheme: colorScheme,
+                          children: [
+                            _CropToolButton(
+                              tooltip: 'Free aspect ratio',
+                              icon: Icons.aspect_ratio,
+                              colorScheme: colorScheme,
+                              selected: aspectMode == _CropAspectMode.free,
+                              onPressed: () {
+                                controller.aspectRatio = null;
+                                controller.crop =
+                                    const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9);
+                                setState(() => aspectMode = _CropAspectMode.free);
+                              },
+                            ),
+                            _CropToolButton(
+                              tooltip: 'Square aspect ratio',
+                              icon: Icons.crop_square,
+                              colorScheme: colorScheme,
+                              selected: aspectMode == _CropAspectMode.square,
+                              onPressed: () {
+                                controller.aspectRatio = 1.0;
+                                controller.crop =
+                                    const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9);
+                                setState(() => aspectMode = _CropAspectMode.square);
+                              },
+                            ),
+                          ],
+                        ),
+                        _CropToolGroup(
+                          colorScheme: colorScheme,
+                          children: [
+                            _CropToolButton(
+                              tooltip: 'Rotate left',
+                              icon: Icons.rotate_90_degrees_ccw_outlined,
+                              colorScheme: colorScheme,
+                              onPressed: () => controller.rotateLeft(),
+                            ),
+                            _CropToolButton(
+                              tooltip: 'Rotate right',
+                              icon: Icons.rotate_90_degrees_cw_outlined,
+                              colorScheme: colorScheme,
+                              onPressed: () => controller.rotateRight(),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        TextButton(
+                          onPressed: cropping ? null : () => Navigator.pop(context),
+                          child: const Text('Cancel'),
+                        ),
+                        const SizedBox(width: 8),
+                        FilledButton.icon(
+                          onPressed: cropping ? null : handleCrop,
+                          icon: cropping
+                              ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child: CircularProgressIndicator(strokeWidth: 2),
+                                )
+                              : const Icon(Icons.check, size: 18),
+                          label: Text(cropping ? 'Cropping…' : 'Crop'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+
+enum _CropAspectMode { free, square }
+
+class _CropToolbar extends StatefulWidget {
+  const _CropToolbar({required this.controller, required this.colorScheme});
+
+  final CropController controller;
+  final ColorScheme colorScheme;
+
+  @override
+  State<_CropToolbar> createState() => _CropToolbarState();
+}
+
+class _CropToolbarState extends State<_CropToolbar> {
+  _CropAspectMode _mode = _CropAspectMode.free;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        _CropToolGroup(
+          colorScheme: widget.colorScheme,
+          children: [
+            _CropToolButton(
+              tooltip: 'Free aspect ratio',
+              icon: Icons.aspect_ratio,
+              colorScheme: widget.colorScheme,
+              selected: _mode == _CropAspectMode.free,
+              onPressed: () {
+                widget.controller.aspectRatio = null;
+                widget.controller.crop = const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9);
+                setState(() => _mode = _CropAspectMode.free);
+              },
+            ),
+            _CropToolButton(
+              tooltip: 'Square aspect ratio',
+              icon: Icons.crop_square,
+              colorScheme: widget.colorScheme,
+              selected: _mode == _CropAspectMode.square,
+              onPressed: () {
+                widget.controller.aspectRatio = 1.0;
+                widget.controller.crop = const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9);
+                setState(() => _mode = _CropAspectMode.square);
+              },
+            ),
+          ],
+        ),
+        _CropToolGroup(
+          colorScheme: widget.colorScheme,
+          children: [
+            _CropToolButton(
+              tooltip: 'Rotate left',
+              icon: Icons.rotate_90_degrees_ccw_outlined,
+              colorScheme: widget.colorScheme,
+              onPressed: widget.controller.rotateLeft,
+            ),
+            _CropToolButton(
+              tooltip: 'Rotate right',
+              icon: Icons.rotate_90_degrees_cw_outlined,
+              colorScheme: widget.colorScheme,
+              onPressed: widget.controller.rotateRight,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _CropActionsRow extends StatefulWidget {
+  const _CropActionsRow({required this.controller, required this.colorScheme});
+
+  final CropController controller;
+  final ColorScheme colorScheme;
+
+  @override
+  State<_CropActionsRow> createState() => _CropActionsRowState();
+}
+
+class _CropActionsRowState extends State<_CropActionsRow> {
+  bool _cropping = false;
+
+  Future<void> _handleCrop() async {
+    setState(() => _cropping = true);
+    try {
+      final ui.Image bitmap = await widget.controller.croppedBitmap();
+      final byteData = await bitmap.toByteData(format: ui.ImageByteFormat.png);
+      if (!mounted) return;
+      if (byteData != null) {
+        Navigator.pop(context, byteData.buffer.asUint8List());
+        return;
+      }
+      botToast('Could not crop image: empty result', second: 4);
+    } catch (e) {
+      if (!mounted) return;
+      botToast('Could not crop image: $e', second: 4);
+    } finally {
+      if (mounted) setState(() => _cropping = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        TextButton(
+          onPressed: _cropping ? null : () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        const SizedBox(width: 8),
+        FilledButton.icon(
+          onPressed: _cropping ? null : _handleCrop,
+          icon: _cropping
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.check, size: 18),
+          label: Text(_cropping ? 'Cropping…' : 'Crop'),
+        ),
+      ],
+    );
+  }
+}
+
+class _CropToolGroup extends StatelessWidget {
+  const _CropToolGroup({required this.colorScheme, required this.children});
+
+  final ColorScheme colorScheme;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(4),
+        child: Row(mainAxisSize: MainAxisSize.min, children: children),
+      ),
+    );
+  }
+}
+
+class _CropToolButton extends StatelessWidget {
+  const _CropToolButton({
+    required this.tooltip,
+    required this.icon,
+    required this.colorScheme,
+    required this.onPressed,
+    this.selected = false,
+  });
+
+  final String tooltip;
+  final IconData icon;
+  final ColorScheme colorScheme;
+  final VoidCallback onPressed;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: Material(
+        color: selected ? colorScheme.primaryContainer : Colors.transparent,
+        borderRadius: BorderRadius.circular(8),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(8),
+          onTap: onPressed,
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: Icon(
+              icon,
+              size: 20,
+              color: selected
+                  ? colorScheme.onPrimaryContainer
+                  : colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/modules/more/settings/dictionary/dictionary_screen.dart
+++ b/lib/modules/more/settings/dictionary/dictionary_screen.dart
@@ -52,6 +52,7 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
   bool _screenAiAvailable = false;
   bool _loading = true;
   bool _importing = false;
+  bool _cropImageBeforeMining = false;
   late DictionaryPopupPreferences _popupPreferences;
   AnkiMiningProfile _ankiProfile = const AnkiMiningProfile();
   AnkiAudioPreferences _ankiAudioPreferences = AnkiAudioPreferences.defaults;
@@ -91,6 +92,7 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
       MiningPreferences.getDictionaryProfiles(),
       MiningPreferences.getActiveDictionaryProfile(),
       MiningPreferences.getMokuroWebsiteOcrEnabled(),
+      MiningPreferences.getCropImageBeforeMining(),
     ]);
     if (!mounted) return;
     setState(() {
@@ -117,6 +119,7 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
       _lookupTrigger = values[14] as DictionaryLookupTrigger;
       _additionalLeftClick = values[15] as bool;
       _dictionaryLanguage = values[16] as String;
+      _cropImageBeforeMining = values[20] as bool;
       _loading = false;
     });
     if (widget.section == DictionarySettingsSection.anki) {
@@ -1587,6 +1590,16 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
                         _saveAnki(_ankiProfile.copyWith(checkAllModels: value)),
                   ),
                 ],
+                SwitchListTile(
+                  secondary: const Icon(Icons.crop_outlined),
+                  title: const Text('Crop manga image before mining'),
+                  subtitle: const Text('Manually crop the page before sending to Anki'),
+                  value: _cropImageBeforeMining,
+                  onChanged: (value) async {
+                    setState(() => _cropImageBeforeMining = value);
+                    await MiningPreferences.setCropImageBeforeMining(value);
+                  },
+                ),
                 SwitchListTile(
                   title: const Text('Sync after adding a note'),
                   value: _ankiProfile.syncOnCreate,

--- a/lib/services/mining/mining_preferences.dart
+++ b/lib/services/mining/mining_preferences.dart
@@ -225,6 +225,9 @@ class MiningPreferences {
   static const _showPitchNumber = 'dictionary_pitch_number';
   static const _showPitchText = 'dictionary_pitch_text';
 
+  // NEW: Feature flag for cropping image before mining
+  static const _cropImageBeforeMining = 'crop_image_before_mining';
+
   static String? _storageDirectory;
   static int _snapshotSequence = 0;
 
@@ -376,6 +379,23 @@ class MiningPreferences {
     }
     final box = await _boxOrNull();
     return box == null ? null : _MiningPreferencesReader.box(box);
+  }
+
+  // NEW: Getter/Setter for crop before mining
+  static Future<bool> getCropImageBeforeMining({
+    bool readOnly = false,
+    MiningPreferencesSnapshot? snapshot,
+  }) async {
+    return (await _reader(
+              readOnly: readOnly,
+              snapshot: snapshot,
+            ))?.get(_cropImageBeforeMining, defaultValue: false)
+            as bool? ??
+        false;
+  }
+
+  static Future<void> setCropImageBeforeMining(bool value) async {
+    await (await _boxOrNull())?.put(_cropImageBeforeMining, value);
   }
 
   static Future<String> getJimakuApiKey({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   archive: ^4.0.9
   desktop_drop: ^0.7.1
   file_picker: ^11.0.2
-  path_provider: ^2.1.5
+  path_provider: ^2.1.6
   scrollable_positioned_list: ^0.3.8
   bot_toast: ^4.1.3
   flutter_web_auth_2: ^4.1.0
@@ -110,7 +110,7 @@ dependencies:
     git:
       url: https://github.com/kodjodevf/m_extension_server.git
   flutter_tts: ^4.2.5
-
+  crop_image: ^1.0.17
 dependency_overrides:
   ffi: ^2.1.3
   html: ^0.15.4


### PR DESCRIPTION
### **Summary**

This PR introduces an in-memory image cropping modal before card creation, allowing users to select and crop specific manga panels or speech bubbles.

---

### **Key Changes**

#### 1. Cross-Platform In-Memory Cropping (`crop_image`)
*   Added the `crop_image` dependency (`pubspec.yaml`).
*   Because `crop_image` is written in pure Dart, the cropping modal works natively across **Windows, macOS, Linux, Android, iOS, and Web** without requiring native OS dependencies or writing temporary files to disk.

#### 2. Portrait-Optimized Responsive Workspace
*   Designed `_showCropDialog` in `hoshi_dictionary_popup.dart` with dynamic height scaling (`(screenSize.height - 48.0).clamp(320.0, 1200.0)`).
*   On desktop displays, the workspace expands vertically to occupy up to ~92–95% of screen height, giving tall portrait manga pages maximum room for precise handle adjustments.

#### 3. Media-Type Awareness
*   The cropping intercept explicitly verifies `effectiveContext.mediaType == MiningMediaType.manga`.
*   Mining subtitles from the Anime video player will automatically bypass the cropper and export full-frame screenshots directly.

#### 4. Settings Configuration
*   Added `_cropImageBeforeMining` to `MiningPreferences` (Hive storage).
*   Added a **"Crop manga image before mining"** toggle switch in `DictionaryScreen` (`dictionary_screen.dart`) under the Anki settings section.

#### Preview
<img width="1905" height="1042" alt="crop" src="https://github.com/user-attachments/assets/bbc6099f-27a2-4261-b08b-e9956c2b865c" />
---

### **Files Changed**
*   **`pubspec.yaml`** — Added `crop_image: ^1.0.17`.
*   **`lib/services/mining/mining_preferences.dart`** — Implemented `getCropImageBeforeMining()` and `setCropImageBeforeMining()`.
*   **`lib/modules/more/settings/dictionary/dictionary_screen.dart`** — Added the setting UI toggle switch under the Anki configuration group.
*   **`lib/modules/mining/widgets/hoshi_dictionary_popup.dart`** — Integrated `_showCropDialog`, overridden `imageBytesLoader` in `MiningContext`, and added aspect ratio & rotation tool controls.
