### PR TITLE
Add Chimahon-compatible immersion statistics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -266,6 +266,7 @@
   "download_queue": "Download Queue",
   "categories": "Categories",
   "statistics": "Statistics",
+  "library_statistics": "Library statistics",
   "settings": "Settings",
   "about": "About",
   "help": "Help",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -887,6 +887,12 @@ abstract class AppLocalizations {
   /// **'Statistics'**
   String get statistics;
 
+  /// No description provided for @library_statistics.
+  ///
+  /// In en, this message translates to:
+  /// **'Library statistics'**
+  String get library_statistics;
+
   /// No description provided for @settings.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -499,6 +499,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get statistics => 'الإحصائيات';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'الإعدادات';
 
   @override

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -488,6 +488,9 @@ class AppLocalizationsAs extends AppLocalizations {
   String get statistics => 'পৰিসংখ্যা';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'ছেটিং';
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -487,6 +487,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get statistics => 'Statistiken';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'Einstellungen';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -487,6 +487,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get statistics => 'Statistics';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'Settings';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -490,6 +490,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get statistics => 'Estadísticas';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'Configuraciones';
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -490,6 +490,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get statistics => 'Statistiques';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'Paramètres';
 
   @override

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -487,6 +487,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get statistics => 'सांख्यिकी';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'सेटिंग्स';
 
   @override

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -489,6 +489,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get statistics => 'Statistik';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'Pengaturan';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -491,6 +491,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get statistics => 'Statistiche';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'Impostazioni';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -481,6 +481,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get statistics => '統計';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => '設定';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -490,6 +490,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get statistics => 'Estatísticas';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'Configurações';
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -499,6 +499,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get statistics => 'Статистика';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'Настройки';
 
   @override

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -487,6 +487,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get statistics => 'สถิติ';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'การตั้งค่า';
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -485,6 +485,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get statistics => 'İstatistikler';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => 'Ayarlar';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -472,6 +472,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get statistics => '统计';
 
   @override
+  String get library_statistics => 'Library statistics';
+
+  @override
   String get settings => '设置';
 
   @override

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -31,6 +31,8 @@ import 'package:mangayomi/modules/manga/reader/widgets/page_indicator.dart';
 import 'package:mangayomi/modules/manga/reader/widgets/image_actions_dialog.dart';
 import 'package:mangayomi/modules/manga/reader/u_chap_data_preload.dart';
 import 'package:mangayomi/modules/mining/widgets/reader_ocr_overlay.dart';
+import 'package:mangayomi/modules/more/statistics/widgets/manga_stats_sheet.dart';
+import 'package:mangayomi/services/statistics/manga_statistics_tracker.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/utils/extensions/others.dart';
 import 'package:mangayomi/utils/riverpod.dart';
@@ -164,6 +166,14 @@ class _MangaChapterPageGalleryState
   final Stopwatch _readingStopwatch = Stopwatch();
   final String _macosPagedWheelOwner = UniqueKey().toString();
 
+  /// Chimahon-compatible immersion statistics for this reading session.
+  late final MangaStatisticsTracker _statsTracker = MangaStatisticsTracker(
+    mangaId: chapter.manga.value?.id ?? 0,
+  );
+
+  /// Rebuilt whenever the sheet is open so its live session values update.
+  final ValueNotifier<int> _statsSheetRevision = ValueNotifier(0);
+
   /// Flag to prevent fullscreen from being disabled when navigating between
   /// chapters via pushReplacement. The old widget's dispose runs after the new
   /// widget is created, which would clobber the new reader's fullscreen state.
@@ -211,6 +221,14 @@ class _MangaChapterPageGalleryState
       );
     }
     disposePreloadManager();
+    // Attribute the page still on screen before the OCR cache goes away.
+    unawaited(
+      _statsTracker.flush(
+        charactersForPage: _charactersForPageIndex,
+        incognito: _statsIncognito,
+      ),
+    );
+    _statsSheetRevision.dispose();
     ReaderOcrState.cancelScan();
     _readerController.keepAliveLink?.close();
     WakelockPlus.disable();
@@ -533,6 +551,7 @@ class _MangaChapterPageGalleryState
                         });
                       },
                       onOcrPressed: _showCurrentPageOcr,
+                      onStatsPressed: _showStatsSheet,
                       onWebViewPressed:
                           (chapter.manga.value!.isLocalArchive ?? false) ==
                               false
@@ -1014,6 +1033,86 @@ class _MangaChapterPageGalleryState
     await ReaderOcrState.toggle();
   }
 
+  /// Opens the immersion statistics sheet for this manga.
+  Future<void> _showStatsSheet() async {
+    final estimate = await _statsEstimate();
+    if (!mounted) return;
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => ValueListenableBuilder<int>(
+        valueListenable: _statsSheetRevision,
+        builder: (context, _, _) => MangaStatsSheet(
+          mangaId: chapter.manga.value?.id ?? 0,
+          session: _statsTracker.session,
+          estimate: estimate,
+          onToggleTracking: () {
+            _statsTracker.toggleTracking();
+            _statsSheetRevision.value++;
+          },
+        ),
+      ),
+    );
+  }
+
+  /// Projects time-to-finish from the session's reading speed.
+  ///
+  /// Remaining characters are estimated from the already-OCRed pages' average
+  /// rather than measured, because pages ahead have not been recognized yet.
+  Future<MangaStatsEstimate> _statsEstimate() async {
+    final speed = _statsTracker.session.charactersPerHour;
+    if (speed <= 0) return const MangaStatsEstimate();
+
+    final actualIndex = _pageViewToActualIndex(_currentIndex ?? 0);
+    final chapterPages = pages
+        .where((page) => page.chapter?.id == chapter.id)
+        .toList();
+    var recognizedPages = 0;
+    var recognizedCharacters = 0;
+    for (final page in chapterPages) {
+      final characters = await ReaderOcrState.cachedCharacterCount(page);
+      if (characters > 0) {
+        recognizedPages++;
+        recognizedCharacters += characters;
+      }
+    }
+    // With nothing recognized there is no basis for a per-page estimate.
+    if (recognizedPages == 0) return const MangaStatsEstimate();
+    final averagePerPage = recognizedCharacters / recognizedPages;
+
+    final chapterRemainingPages =
+        (chapterPages.length - _chapterPageOffset(actualIndex) - 1)
+            .clamp(0, chapterPages.length)
+            .toInt();
+    final bookRemainingPages = (pages.length - actualIndex - 1)
+        .clamp(0, pages.length)
+        .toInt();
+    final chapterCharacters = (averagePerPage * chapterRemainingPages).round();
+    final bookCharacters = (averagePerPage * bookRemainingPages).round();
+
+    return MangaStatsEstimate(
+      remainingChapterCharacters: chapterCharacters,
+      remainingBookCharacters: bookCharacters,
+      remainingChapterSeconds: MangaStatsEstimate.secondsRemaining(
+        chapterCharacters,
+        speed,
+      ),
+      remainingBookSeconds: MangaStatsEstimate.secondsRemaining(
+        bookCharacters,
+        speed,
+      ),
+    );
+  }
+
+  /// Index of [actualIndex] within its own chapter's pages.
+  int _chapterPageOffset(int actualIndex) {
+    var offset = 0;
+    for (var i = 0; i < actualIndex && i < pages.length; i++) {
+      if (pages[i].chapter?.id == chapter.id) offset++;
+    }
+    return offset;
+  }
+
   void _initCurrentIndex() async {
     if (ref.read(cropBordersStateProvider)) _processCropBorders();
     final readerMode = _readerController.getReaderMode();
@@ -1272,7 +1371,27 @@ class _MangaChapterPageGalleryState
     // Prefetch pages in order for the new page window
     _prefetchPagesInOrder();
     _scanCurrentChapterOcr(actualIndex: actualIndex);
+    unawaited(_trackStatsForPage(actualIndex));
   }
+
+  /// Records the page just left into immersion statistics.
+  Future<void> _trackStatsForPage(int actualIndex) async {
+    await _statsTracker.onPageChanged(
+      pageIndex: actualIndex,
+      charactersForPage: _charactersForPageIndex,
+      incognito: _statsIncognito,
+    );
+    if (mounted) _statsSheetRevision.value++;
+  }
+
+  /// OCR character count for a page, or zero if it has not been recognized.
+  Future<int> _charactersForPageIndex(int actualIndex) async {
+    if (actualIndex < 0 || actualIndex >= pages.length) return 0;
+    return ReaderOcrState.cachedCharacterCount(pages[actualIndex]);
+  }
+
+  bool get _statsIncognito =>
+      isar.settings.getSync(227)?.incognitoMode ?? false;
 
   late final _pageOffset = ValueNotifier(
     _readerController.autoScrollValues().$2,

--- a/lib/modules/manga/reader/widgets/reader_app_bar.dart
+++ b/lib/modules/manga/reader/widgets/reader_app_bar.dart
@@ -57,6 +57,9 @@ class ReaderAppBar extends ConsumerWidget {
   /// Callback that opens the OCR overlay for the visible page.
   final VoidCallback? onOcrPressed;
 
+  /// Callback that opens the immersion statistics sheet.
+  final VoidCallback? onStatsPressed;
+
   /// Overrides route replacement when a reader can navigate chapters in place.
   final ValueChanged<Chapter>? onChapterSelected;
 
@@ -74,6 +77,7 @@ class ReaderAppBar extends ConsumerWidget {
     required this.onBookmarkPressed,
     this.onWebViewPressed,
     this.onOcrPressed,
+    this.onStatsPressed,
     this.onChapterSelected,
     required this.backgroundColor,
   });
@@ -146,6 +150,13 @@ class ReaderAppBar extends ConsumerWidget {
                   : Icons.document_scanner_outlined,
             ),
           ),
+        ),
+
+      if (onStatsPressed != null)
+        IconButton(
+          tooltip: 'Statistics',
+          onPressed: onStatsPressed,
+          icon: const Icon(Icons.query_stats_outlined),
         ),
 
       // Chapter list button

--- a/lib/modules/mining/widgets/dictionary_lookup_popup.dart
+++ b/lib/modules/mining/widgets/dictionary_lookup_popup.dart
@@ -14,6 +14,7 @@ import 'package:mangayomi/services/mining/dictionary_profile.dart';
 import 'package:mangayomi/services/mining/dictionary_profile_resolver.dart';
 import 'package:mangayomi/services/mining/mining_models.dart';
 import 'package:mangayomi/services/mining/mining_preferences.dart';
+import 'package:mangayomi/services/statistics/anki_stats_recorder.dart';
 import 'package:mangayomi/src/rust/api/hoshidicts.dart';
 
 class DictionaryPopupHandle {
@@ -1068,6 +1069,10 @@ class _DictionaryLookupResultsViewState
             checkAllModels: profile.checkAllModels,
             syncOnCreate: profile.syncOnCreate,
           );
+      await AnkiStatsRecorder.recordCard(
+        context: widget.miningContext,
+        profile: dictionaryProfile,
+      );
       botToast('Added to Anki (#$noteId)', second: 3);
     } on AnkiDuplicateException {
       botToast('Already in Anki', second: 3);

--- a/lib/modules/mining/widgets/hoshi_dictionary_popup.dart
+++ b/lib/modules/mining/widgets/hoshi_dictionary_popup.dart
@@ -19,6 +19,7 @@ import 'package:mangayomi/services/mining/anki_connect_service.dart';
 import 'package:mangayomi/services/mining/dictionary_profile.dart';
 import 'package:mangayomi/services/mining/mining_models.dart';
 import 'package:mangayomi/services/mining/mining_preferences.dart';
+import 'package:mangayomi/services/statistics/anki_stats_recorder.dart';
 import 'package:mangayomi/src/rust/api/hoshidicts.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -507,6 +508,10 @@ class _HoshiDictionaryPopupState extends State<HoshiDictionaryPopup> {
             checkAllModels: profile.checkAllModels,
             syncOnCreate: profile.syncOnCreate,
           );
+      await AnkiStatsRecorder.recordCard(
+        context: effectiveContext,
+        profile: dictionaryProfile,
+      );
       botToast('Added to Anki (#$noteId)', second: 3);
       return true;
     } on AnkiDuplicateException {

--- a/lib/modules/mining/widgets/reader_ocr_overlay.dart
+++ b/lib/modules/mining/widgets/reader_ocr_overlay.dart
@@ -469,6 +469,25 @@ class ReaderOcrState {
       stage: stage,
     );
   }
+
+  /// Recognized character count for [data], for reading statistics.
+  ///
+  /// This only consults the OCR cache: a page whose recognition has not
+  /// finished contributes zero characters rather than blocking a page turn or
+  /// triggering OCR the reader did not ask for. Chimahon behaves the same way
+  /// (`getCachedOcrBlocks`), so an un-OCRed page counts time but no characters.
+  static Future<int> cachedCharacterCount(UChapDataPreload data) async {
+    for (final controller in _controllers) {
+      if (!identical(controller.data, data)) continue;
+      final page = controller._page;
+      if (page == null) return 0;
+      return page.blocks.fold<int>(
+        0,
+        (sum, block) => sum + block.text.length,
+      );
+    }
+    return 0;
+  }
 }
 
 enum ReaderOcrProgressStage { recognizing, loadingMokuro, mokuro }

--- a/lib/modules/more/data_and_storage/providers/restore.dart
+++ b/lib/modules/more/data_and_storage/providers/restore.dart
@@ -33,6 +33,9 @@ import 'package:mangayomi/services/sync/chimahon_local_sync_projection_service.d
 import 'package:mangayomi/services/sync/chimahon_media_sync_selection.dart';
 import 'package:mangayomi/services/sync/chimahon_manga_title_adapter.dart';
 import 'package:mangayomi/services/sync/chimahon_novel_materializer.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_storage.dart';
+import 'package:mangayomi/services/sync/chimahon_stats_adapter.dart';
 import 'package:mangayomi/services/sync/chimahon_sync_importer.dart';
 import 'package:mangayomi/services/sync/chimahon_sync_codec.dart';
 import 'package:mangayomi/services/sync/chimahon_restore_sync_coordinator.dart';
@@ -855,6 +858,7 @@ Future<void> _restoreTachiBkBackupDataExclusive(
     isar.updates.clearSync();
   });
   await _importChimahonSettings(backup);
+  await _importImmersionStats(backup, replace: true);
   _importChimahonMediaSelection(backup);
   ref.invalidate(synchingProvider(syncId: 1));
   if (pendingStore case ChimahonLocalPreferenceBaselineStore preferenceStore) {
@@ -884,6 +888,42 @@ Future<void> _restoreTachiBkBackupDataExclusive(
     await lifecycle.markReady();
   }
   _invalidateCommonState(ref);
+}
+
+/// Restores immersion statistics from a Chimahon-compatible backup.
+///
+/// A manual restore is an explicit "make this device look like the backup", so
+/// it replaces the local rows. Sync merges instead, because both sides may hold
+/// reading the other has not seen.
+Future<void> _importImmersionStats(
+  BackupMihon backup, {
+  required bool replace,
+}) async {
+  const adapter = ChimahonStatsAdapter();
+  final mangaStats = adapter.importAllMangaStats(backup.backupMangaStats);
+  final ankiStats = adapter.importAllAnkiStats(backup.backupAnkiStats);
+  final novelStats = <String, List<NovelStatsEntry>>{};
+  for (final novel in backup.backupNovels) {
+    if (novel.stats.isEmpty || novel.id.isEmpty) continue;
+    novelStats
+        .putIfAbsent(novel.id, () => [])
+        .addAll(adapter.importAllNovelStats(novel.stats));
+  }
+
+  if (replace) {
+    await ImmersionStatsStorage.clear();
+    await ImmersionStatsStorage.saveMangaStats(mangaStats);
+    await ImmersionStatsStorage.saveAnkiStats(ankiStats);
+    for (final entry in novelStats.entries) {
+      await ImmersionStatsStorage.saveNovelStats(entry.key, entry.value);
+    }
+    return;
+  }
+  await ImmersionStatsStorage.mergeMangaStats(mangaStats);
+  await ImmersionStatsStorage.mergeAnkiStats(ankiStats);
+  for (final entry in novelStats.entries) {
+    await ImmersionStatsStorage.mergeNovelStats(entry.key, entry.value);
+  }
 }
 
 void _importChimahonMediaSelection(BackupMihon backup) {
@@ -930,6 +970,7 @@ Future<void> restoreChimahonSyncData(Ref ref, BackupMihon backup) async {
     backup,
     preserveUnrepresentableLocalSettings: true,
   );
+  await _importImmersionStats(backup, replace: false);
   _invalidateCommonState(ref);
 }
 

--- a/lib/modules/more/more_screen.dart
+++ b/lib/modules/more/more_screen.dart
@@ -96,10 +96,17 @@ class MoreScreenState extends ConsumerState<MoreScreen> {
             ),
             ListTileWidget(
               onTap: () {
-                context.push('/statistics');
+                context.push('/statistics/immersion');
               },
               icon: Icons.query_stats_outlined,
               title: l10n.statistics,
+            ),
+            ListTileWidget(
+              onTap: () {
+                context.push('/statistics');
+              },
+              icon: Icons.pie_chart_outline,
+              title: l10n.library_statistics,
             ),
             ListTileWidget(
               onTap: () {

--- a/lib/modules/more/statistics/immersion_stats_data.dart
+++ b/lib/modules/more/statistics/immersion_stats_data.dart
@@ -1,0 +1,236 @@
+/// Value types for the immersion statistics screen, ported from Chimahon's
+/// `StatsData` / `StatsScreenState`.
+library;
+
+/// Which library the screen is reporting on.
+enum ImmersionStatsType { all, manga, novels }
+
+/// The window the screen aggregates over.
+enum ImmersionStatsDateScale { day, week, month, year, allTime }
+
+/// One bar in the hero chart.
+class ImmersionHistoryPoint {
+  const ImmersionHistoryPoint({
+    required this.label,
+    required this.durationMs,
+    required this.dateOffset,
+  });
+
+  final String label;
+  final int durationMs;
+
+  /// Offset from the current period, in the units of the active scale. Tapping
+  /// a bar navigates to this offset.
+  final int dateOffset;
+}
+
+/// Everything the stats screen renders for one filter combination.
+class ImmersionStatsOverview {
+  const ImmersionStatsOverview({
+    this.libraryTitleCount = 0,
+    this.completedTitleCount = 0,
+    this.startedTitleCount = 0,
+    this.localTitleCount = 0,
+    this.totalReadDurationMs = 0,
+    this.readingStreak = 0,
+    this.historyPoints = const [],
+    this.avgDurationPerDayMs,
+    this.ankiCardsAdded = 0,
+    this.charactersRead = 0,
+    this.charactersPerHour,
+    this.totalChapterCount = 0,
+    this.readChapterCount = 0,
+    this.downloadedChapterCount = 0,
+    this.trackedTitleCount = 0,
+    this.meanScore = 0,
+    this.trackerCount = 0,
+  });
+
+  final int libraryTitleCount;
+  final int completedTitleCount;
+  final int startedTitleCount;
+  final int localTitleCount;
+  final int totalReadDurationMs;
+  final int readingStreak;
+  final List<ImmersionHistoryPoint> historyPoints;
+
+  /// Null for the day and all-time scales, where a per-day average is either
+  /// the value itself or spans an unknown number of days.
+  final int? avgDurationPerDayMs;
+  final int ankiCardsAdded;
+  final int charactersRead;
+
+  /// Null when no time was recorded, so the UI can distinguish "no data" from
+  /// a genuine zero.
+  final int? charactersPerHour;
+  final int totalChapterCount;
+  final int readChapterCount;
+  final int downloadedChapterCount;
+  final int trackedTitleCount;
+  final double meanScore;
+  final int trackerCount;
+}
+
+/// The filter tuple the screen requests statistics for.
+class ImmersionStatsQuery {
+  const ImmersionStatsQuery({
+    this.type = ImmersionStatsType.all,
+    this.scale = ImmersionStatsDateScale.day,
+    this.offset = 0,
+    this.profileId,
+    this.titleId,
+    this.isNovel = false,
+    this.includeNonLibrary = true,
+  });
+
+  final ImmersionStatsType type;
+  final ImmersionStatsDateScale scale;
+
+  /// Zero is the current period; negative values move into the past.
+  final int offset;
+
+  /// Null means every dictionary profile.
+  final String? profileId;
+
+  /// Set for the single-title view. Manga use the Isar ID as a string; novels
+  /// use Chimahon's stable book ID.
+  final String? titleId;
+  final bool isNovel;
+
+  /// Chimahon's "include all read entries" toggle: when false, only titles
+  /// currently in the library are counted.
+  final bool includeNonLibrary;
+
+  ImmersionStatsQuery copyWith({
+    ImmersionStatsType? type,
+    ImmersionStatsDateScale? scale,
+    int? offset,
+    String? profileId,
+    bool clearProfileId = false,
+    String? titleId,
+    bool? isNovel,
+    bool? includeNonLibrary,
+  }) => ImmersionStatsQuery(
+    type: type ?? this.type,
+    scale: scale ?? this.scale,
+    offset: offset ?? this.offset,
+    profileId: clearProfileId ? null : (profileId ?? this.profileId),
+    titleId: titleId ?? this.titleId,
+    isNovel: isNovel ?? this.isNovel,
+    includeNonLibrary: includeNonLibrary ?? this.includeNonLibrary,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      other is ImmersionStatsQuery &&
+      other.type == type &&
+      other.scale == scale &&
+      other.offset == offset &&
+      other.profileId == profileId &&
+      other.titleId == titleId &&
+      other.isNovel == isNovel &&
+      other.includeNonLibrary == includeNonLibrary;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    scale,
+    offset,
+    profileId,
+    titleId,
+    isNovel,
+    includeNonLibrary,
+  );
+}
+
+/// One row in the per-title statistics list.
+class ImmersionStatsTitle {
+  const ImmersionStatsTitle({
+    required this.id,
+    required this.title,
+    this.author,
+    this.isNovel = false,
+    this.mangaId,
+    this.lastReadDate,
+    this.readDurationMs = 0,
+    this.charactersRead = 0,
+    this.dateAdded = 0,
+  });
+
+  final String id;
+  final String title;
+  final String? author;
+  final bool isNovel;
+
+  /// Local Isar ID, used to load the cover. Novels resolve theirs through the
+  /// parent library entry.
+  final int? mangaId;
+  final DateTime? lastReadDate;
+  final int readDurationMs;
+  final int charactersRead;
+  final int dateAdded;
+}
+
+/// Sort orders for the per-title list.
+enum ImmersionStatsTitlesSort { alphabetical, lastRead, dateAdded }
+
+/// Inclusive date window for a scale/offset pair.
+class ImmersionStatsDateRange {
+  const ImmersionStatsDateRange(this.start, this.end);
+
+  final DateTime start;
+  final DateTime end;
+
+  bool containsKey(String dateKey) =>
+      dateKey.compareTo(_key(start)) >= 0 && dateKey.compareTo(_key(end)) <= 0;
+
+  static String _key(DateTime date) =>
+      '${date.year.toString().padLeft(4, '0')}-'
+      '${date.month.toString().padLeft(2, '0')}-'
+      '${date.day.toString().padLeft(2, '0')}';
+}
+
+/// Resolves the window a scale/offset pair covers.
+///
+/// All-time uses Chimahon's fixed 2000-01-01 lower bound, which predates any
+/// possible reading record.
+ImmersionStatsDateRange immersionStatsDateRange(
+  ImmersionStatsDateScale scale,
+  int offset, {
+  DateTime? now,
+}) {
+  final today = _dateOnly(now ?? DateTime.now());
+  switch (scale) {
+    case ImmersionStatsDateScale.day:
+      final date = today.add(Duration(days: offset));
+      return ImmersionStatsDateRange(date, date);
+    case ImmersionStatsDateScale.week:
+      final shifted = today.add(Duration(days: offset * 7));
+      final start = _startOfWeek(shifted);
+      return ImmersionStatsDateRange(start, start.add(const Duration(days: 6)));
+    case ImmersionStatsDateScale.month:
+      final start = _addMonths(DateTime(today.year, today.month), offset);
+      final end = _addMonths(start, 1).subtract(const Duration(days: 1));
+      return ImmersionStatsDateRange(start, _dateOnly(end));
+    case ImmersionStatsDateScale.year:
+      final start = DateTime(today.year + offset);
+      return ImmersionStatsDateRange(start, DateTime(start.year, 12, 31));
+    case ImmersionStatsDateScale.allTime:
+      return ImmersionStatsDateRange(DateTime(2000), today);
+  }
+}
+
+DateTime _dateOnly(DateTime date) => DateTime(date.year, date.month, date.day);
+
+/// Chimahon's weeks start on Monday (`with(DayOfWeek.MONDAY)`).
+DateTime _startOfWeek(DateTime date) =>
+    _dateOnly(date).subtract(Duration(days: date.weekday - DateTime.monday));
+
+/// Adds months without overflowing into the next month for short months.
+DateTime _addMonths(DateTime date, int months) {
+  final totalMonths = date.year * 12 + (date.month - 1) + months;
+  final year = totalMonths ~/ 12;
+  final month = totalMonths % 12 + 1;
+  final lastDay = DateTime(year, month + 1, 0).day;
+  return DateTime(year, month, date.day > lastDay ? lastDay : date.day);
+}

--- a/lib/modules/more/statistics/immersion_stats_provider.dart
+++ b/lib/modules/more/statistics/immersion_stats_provider.dart
@@ -1,0 +1,859 @@
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/models/download.dart';
+import 'package:mangayomi/models/epub_book_progress.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/models/source.dart';
+import 'package:mangayomi/models/track.dart';
+import 'package:mangayomi/models/track_preference.dart';
+import 'package:mangayomi/modules/more/statistics/immersion_stats_data.dart';
+import 'package:mangayomi/services/mining/dictionary_profile.dart';
+import 'package:mangayomi/services/mining/dictionary_profile_resolver.dart';
+import 'package:mangayomi/services/mining/mining_preferences.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_storage.dart';
+import 'package:mangayomi/services/sync/chimahon_novel_progress_adapter.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'immersion_stats_provider.g.dart';
+
+/// Aggregates immersion statistics for one filter combination.
+///
+/// This is the Dart counterpart of Chimahon's `StatsScreenModel`. Manga rows
+/// hold milliseconds and novel rows hold seconds, so every novel value is
+/// converted at the point of use rather than at load time — matching Chimahon
+/// and keeping the persisted schema byte-compatible.
+@riverpod
+Future<ImmersionStatsOverview> immersionStats(
+  Ref ref, {
+  required ImmersionStatsQuery query,
+}) async {
+  // Rebuild whenever a reader or a mined card writes new statistics.
+  _watchStatsRevision(ref);
+
+  final profiles = await MiningPreferences.getDictionaryProfiles();
+  final singleTitle = query.titleId != null;
+  final type = singleTitle
+      ? (query.isNovel ? ImmersionStatsType.novels : ImmersionStatsType.manga)
+      : query.type;
+  final range = immersionStatsDateRange(query.scale, query.offset);
+
+  // ---------------------------------------------------------------- library
+  final wantsManga =
+      type == ImmersionStatsType.all || type == ImmersionStatsType.manga;
+  final wantsNovels =
+      type == ImmersionStatsType.all || type == ImmersionStatsType.novels;
+
+  final mangaEntries = wantsManga
+      ? await _mangaEntries(
+          titleId: singleTitle && !query.isNovel ? query.titleId : null,
+          includeNonLibrary: query.includeNonLibrary,
+        )
+      : const <Manga>[];
+  final novelBooks = wantsNovels
+      ? await _novelBooks(
+          titleId: singleTitle && query.isNovel ? query.titleId : null,
+        )
+      : const <_NovelBook>[];
+
+  final profileFilteredManga = await _filterMangaByProfile(
+    mangaEntries,
+    query.profileId,
+  );
+  final profileFilteredNovels = await _filterNovelsByProfile(
+    novelBooks,
+    query.profileId,
+  );
+
+  // ------------------------------------------------------------ manga stats
+  var mangaStats = await ImmersionStatsStorage.loadMangaStats();
+  if (singleTitle) {
+    mangaStats = query.isNovel
+        ? const []
+        : mangaStats
+              .where((entry) => entry.mangaId.toString() == query.titleId)
+              .toList();
+  }
+  mangaStats = await _filterMangaStatsByProfile(mangaStats, query.profileId);
+  if (!query.includeNonLibrary) {
+    final libraryIds = {
+      for (final manga in profileFilteredManga)
+        if (manga.id != null) manga.id!,
+    };
+    // Chimahon keeps the id-0 bucket (reading with no library entry) even when
+    // non-library titles are excluded, because it is not attributable.
+    mangaStats = mangaStats
+        .where((entry) => entry.mangaId == 0 || libraryIds.contains(entry.mangaId))
+        .toList();
+  }
+  final unscopedMangaStats = mangaStats;
+  final scopedMangaStats = mangaStats
+      .where((entry) => range.containsKey(entry.dateKey))
+      .toList();
+
+  // ------------------------------------------------------------ novel stats
+  final storedNovelStats = await ImmersionStatsStorage.loadAllNovelStats();
+  final novelStatsByBook = <String, List<NovelStatsEntry>>{
+    for (final book in profileFilteredNovels)
+      if (storedNovelStats[book.chimahonId] != null)
+        book.chimahonId: storedNovelStats[book.chimahonId]!,
+  };
+  final unscopedNovelStats = novelStatsByBook.values
+      .expand((entries) => entries)
+      .toList();
+  final scopedNovelStats = unscopedNovelStats
+      .where((entry) => range.containsKey(entry.dateKey))
+      .toList();
+
+  // -------------------------------------------------------------- totals
+  final mangaChars = scopedMangaStats.fold(
+    0,
+    (sum, entry) => sum + entry.charactersRead,
+  );
+  final mangaTimeMs = scopedMangaStats.fold(
+    0,
+    (sum, entry) => sum + entry.readingTimeMs,
+  );
+  final novelChars = scopedNovelStats.fold(
+    0,
+    (sum, entry) => sum + entry.charactersRead,
+  );
+  final novelTimeMs = scopedNovelStats.fold(
+    0,
+    (sum, entry) => sum + entry.readingTimeMs,
+  );
+
+  final totalChars = switch (type) {
+    ImmersionStatsType.all => mangaChars + novelChars,
+    ImmersionStatsType.manga => mangaChars,
+    ImmersionStatsType.novels => novelChars,
+  };
+  final totalTimeMs = switch (type) {
+    ImmersionStatsType.all => mangaTimeMs + novelTimeMs,
+    ImmersionStatsType.manga => mangaTimeMs,
+    ImmersionStatsType.novels => novelTimeMs,
+  };
+
+  // --------------------------------------------------------------- anki
+  var ankiStats = await ImmersionStatsStorage.loadAnkiStats();
+  if (singleTitle) {
+    ankiStats = ankiStats
+        .where((entry) => entry.titleId == query.titleId)
+        .toList();
+  }
+  final scopedAnki = ankiStats
+      .where((entry) => range.containsKey(entry.dateKey))
+      .toList();
+  final profileFilteredAnki = _filterAnkiByProfile(
+    scopedAnki,
+    query.profileId,
+    profiles,
+  );
+  final ankiCards = switch (type) {
+    ImmersionStatsType.all => profileFilteredAnki.fold(
+      0,
+      (sum, entry) => sum + entry.totalCards,
+    ),
+    ImmersionStatsType.manga => profileFilteredAnki.fold(
+      0,
+      (sum, entry) => sum + entry.mangaCards,
+    ),
+    ImmersionStatsType.novels => profileFilteredAnki.fold(
+      0,
+      (sum, entry) => sum + entry.novelCards,
+    ),
+  };
+
+  // ---------------------------------------------------------- chapters
+  final chapterTotals = await _chapterTotals(
+    profileFilteredManga,
+    profileFilteredNovels,
+    type,
+  );
+
+  // ---------------------------------------------------------- trackers
+  final trackerTotals = singleTitle
+      ? const _TrackerTotals(0, 0, 0)
+      : await _trackerTotals(profileFilteredManga);
+
+  // ------------------------------------------------------------- derived
+  // The streak and chart deliberately use the *unscoped* rows: a streak is a
+  // property of the whole history, and the chart shows periods outside the
+  // selected window so it can be navigated.
+  final streak = _readingStreak(unscopedMangaStats, unscopedNovelStats);
+  final historyPoints = _historyPoints(
+    mangaStats: unscopedMangaStats,
+    novelStats: unscopedNovelStats,
+    scale: query.scale,
+    offset: query.offset,
+  );
+
+  final days = range.end.difference(range.start).inDays + 1;
+  final avgPerDay =
+      query.scale != ImmersionStatsDateScale.day &&
+          query.scale != ImmersionStatsDateScale.allTime &&
+          days > 0
+      ? totalTimeMs ~/ days
+      : null;
+
+  return ImmersionStatsOverview(
+    libraryTitleCount: switch (type) {
+      ImmersionStatsType.all =>
+        profileFilteredManga.length + profileFilteredNovels.length,
+      ImmersionStatsType.manga => profileFilteredManga.length,
+      ImmersionStatsType.novels => profileFilteredNovels.length,
+    },
+    completedTitleCount: _completedCount(profileFilteredManga, type),
+    startedTitleCount: await _startedCount(
+      profileFilteredManga,
+      profileFilteredNovels,
+      novelStatsByBook,
+      type,
+    ),
+    localTitleCount: switch (type) {
+      ImmersionStatsType.all =>
+        profileFilteredManga
+                .where((manga) => manga.isLocalArchive == true)
+                .length +
+            profileFilteredNovels.length,
+      ImmersionStatsType.manga => profileFilteredManga
+          .where((manga) => manga.isLocalArchive == true)
+          .length,
+      ImmersionStatsType.novels => profileFilteredNovels.length,
+    },
+    totalReadDurationMs: totalTimeMs,
+    readingStreak: streak,
+    historyPoints: historyPoints,
+    avgDurationPerDayMs: avgPerDay,
+    ankiCardsAdded: ankiCards,
+    charactersRead: totalChars,
+    charactersPerHour: totalTimeMs > 0
+        ? (totalChars / (totalTimeMs / 3600000)).toInt()
+        : null,
+    totalChapterCount: chapterTotals.total,
+    readChapterCount: chapterTotals.read,
+    downloadedChapterCount: chapterTotals.downloaded,
+    trackedTitleCount: trackerTotals.trackedTitles,
+    meanScore: trackerTotals.meanScore,
+    trackerCount: trackerTotals.trackerCount,
+  );
+}
+
+/// The per-title list backing the "In library" card drill-down.
+@riverpod
+Future<List<ImmersionStatsTitle>> immersionStatsTitles(
+  Ref ref, {
+  required ImmersionStatsQuery query,
+  required ImmersionStatsTitlesSort sort,
+  String? search,
+}) async {
+  _watchStatsRevision(ref);
+
+  final wantsManga =
+      query.type == ImmersionStatsType.all ||
+      query.type == ImmersionStatsType.manga;
+  final wantsNovels =
+      query.type == ImmersionStatsType.all ||
+      query.type == ImmersionStatsType.novels;
+
+  final mangaEntries = wantsManga
+      ? await _filterMangaByProfile(
+          await _mangaEntries(
+            titleId: null,
+            includeNonLibrary: query.includeNonLibrary,
+          ),
+          query.profileId,
+        )
+      : const <Manga>[];
+  final novelBooks = wantsNovels
+      ? await _filterNovelsByProfile(
+          await _novelBooks(titleId: null),
+          query.profileId,
+        )
+      : const <_NovelBook>[];
+
+  final mangaStats = await ImmersionStatsStorage.loadMangaStats();
+  final statsByManga = <int, List<MangaStatsEntry>>{};
+  for (final entry in mangaStats) {
+    statsByManga.putIfAbsent(entry.mangaId, () => []).add(entry);
+  }
+  final novelStats = await ImmersionStatsStorage.loadAllNovelStats();
+
+  final items = <ImmersionStatsTitle>[];
+  for (final manga in mangaEntries) {
+    final id = manga.id;
+    if (id == null) continue;
+    final stats = statsByManga[id] ?? const <MangaStatsEntry>[];
+    items.add(
+      ImmersionStatsTitle(
+        id: id.toString(),
+        title: manga.name ?? '',
+        author: manga.author,
+        mangaId: id,
+        lastReadDate: _latestDate(stats.map((entry) => entry.dateKey)),
+        readDurationMs: stats.fold(
+          0,
+          (sum, entry) => sum + entry.readingTimeMs,
+        ),
+        charactersRead: stats.fold(
+          0,
+          (sum, entry) => sum + entry.charactersRead,
+        ),
+        dateAdded: manga.dateAdded ?? 0,
+      ),
+    );
+  }
+  for (final book in novelBooks) {
+    final stats = novelStats[book.chimahonId] ?? const <NovelStatsEntry>[];
+    items.add(
+      ImmersionStatsTitle(
+        id: book.chimahonId,
+        title: book.title,
+        author: book.author,
+        isNovel: true,
+        mangaId: book.mangaId,
+        lastReadDate: _latestDate(stats.map((entry) => entry.dateKey)),
+        readDurationMs: stats.fold(
+          0,
+          (sum, entry) => sum + entry.readingTimeMs,
+        ),
+        charactersRead: stats.fold(
+          0,
+          (sum, entry) => sum + entry.charactersRead,
+        ),
+        dateAdded: book.dateAdded,
+      ),
+    );
+  }
+
+  final query0 = search?.trim().toLowerCase();
+  final filtered = query0 == null || query0.isEmpty
+      ? items
+      : items
+            .where(
+              (item) =>
+                  item.title.toLowerCase().contains(query0) ||
+                  (item.author?.toLowerCase().contains(query0) ?? false),
+            )
+            .toList();
+
+  switch (sort) {
+    case ImmersionStatsTitlesSort.alphabetical:
+      filtered.sort(
+        (a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase()),
+      );
+    case ImmersionStatsTitlesSort.lastRead:
+      filtered.sort((a, b) {
+        // Titles with any reading history sort above those without.
+        final aHas = a.lastReadDate != null;
+        final bHas = b.lastReadDate != null;
+        if (aHas != bHas) return aHas ? -1 : 1;
+        if (aHas && bHas) {
+          final byDate = b.lastReadDate!.compareTo(a.lastReadDate!);
+          if (byDate != 0) return byDate;
+        }
+        final byDuration = b.readDurationMs.compareTo(a.readDurationMs);
+        if (byDuration != 0) return byDuration;
+        return a.title.compareTo(b.title);
+      });
+    case ImmersionStatsTitlesSort.dateAdded:
+      filtered.sort((a, b) {
+        final byDate = b.dateAdded.compareTo(a.dateAdded);
+        return byDate != 0 ? byDate : a.title.compareTo(b.title);
+      });
+  }
+  return filtered;
+}
+
+/// Dictionary profiles available as a filter.
+@riverpod
+Future<List<DictionaryProfile>> immersionStatsProfiles(Ref ref) =>
+    MiningPreferences.getDictionaryProfiles();
+
+/// Rebuilds the provider whenever statistics are written.
+void _watchStatsRevision(Ref ref) {
+  void onChanged() => ref.invalidateSelf();
+  ImmersionStatsStorage.revision.addListener(onChanged);
+  ref.onDispose(
+    () => ImmersionStatsStorage.revision.removeListener(onChanged),
+  );
+}
+
+// --------------------------------------------------------------- library IO
+
+Future<List<Manga>> _mangaEntries({
+  required String? titleId,
+  required bool includeNonLibrary,
+}) async {
+  if (titleId != null) {
+    final id = int.tryParse(titleId);
+    if (id == null) return const [];
+    final manga = await isar.mangas.get(id);
+    return manga == null ? const [] : [manga];
+  }
+  // Chimahon's "include all read entries" adds titles that were read but are
+  // not (or no longer) favourites; those still have a Manga row locally.
+  final query = isar.mangas.filter().itemTypeEqualTo(ItemType.manga);
+  return includeNonLibrary
+      ? query.findAll()
+      : query.favoriteEqualTo(true).findAll();
+}
+
+/// One EPUB with a Chimahon-representable identity.
+class _NovelBook {
+  const _NovelBook({
+    required this.chimahonId,
+    required this.title,
+    this.author,
+    this.mangaId,
+    this.dateAdded = 0,
+  });
+
+  final String chimahonId;
+  final String title;
+  final String? author;
+  final int? mangaId;
+  final int dateAdded;
+}
+
+Future<List<_NovelBook>> _novelBooks({required String? titleId}) async {
+  const adapter = ChimahonNovelProgressAdapter();
+  final progresses = await isar.epubBookProgress.where().findAll();
+  final parentDates = <int, int>{};
+  final books = <String, _NovelBook>{};
+  for (final progress in progresses) {
+    final id = adapter.stableLocalIdOrNull(progress);
+    if (id == null) continue;
+    if (titleId != null && id != titleId) continue;
+    parentDates[progress.mangaId] ??=
+        (await isar.mangas.get(progress.mangaId))?.dateAdded ?? 0;
+    // A duplicate identity means the same book imported twice; the first row
+    // wins so a title is never double counted.
+    books.putIfAbsent(
+      id,
+      () => _NovelBook(
+        chimahonId: id,
+        title: progress.title,
+        author: progress.author,
+        mangaId: progress.mangaId,
+        dateAdded: parentDates[progress.mangaId] ?? 0,
+      ),
+    );
+  }
+  return books.values.toList();
+}
+
+// ------------------------------------------------------------ profile filters
+
+Future<List<Manga>> _filterMangaByProfile(
+  List<Manga> entries,
+  String? profileId,
+) async {
+  if (profileId == null || entries.isEmpty) return entries;
+  final kept = <Manga>[];
+  for (final manga in entries) {
+    if (await _mangaProfileId(manga) == profileId) kept.add(manga);
+  }
+  return kept;
+}
+
+Future<String?> _mangaProfileId(Manga manga) async {
+  final source = manga.sourceId == null
+      ? null
+      : await isar.sources.get(manga.sourceId!);
+  final resolved = await DictionaryProfileResolver.resolve(
+    mangaId: manga.id,
+    sourceId: DictionaryProfileResolver.overrideIdForSource(source),
+    sourceLanguage: DictionaryProfileResolver.sourceLanguageForSource(
+      source,
+      fallback: manga.lang ?? '',
+    ),
+  );
+  return resolved.id;
+}
+
+Future<List<_NovelBook>> _filterNovelsByProfile(
+  List<_NovelBook> books,
+  String? profileId,
+) async {
+  if (profileId == null || books.isEmpty) return books;
+  final kept = <_NovelBook>[];
+  for (final book in books) {
+    final resolved = await DictionaryProfileResolver.resolve(
+      novelId: book.chimahonId,
+    );
+    if (resolved.id == profileId) kept.add(book);
+  }
+  return kept;
+}
+
+Future<List<MangaStatsEntry>> _filterMangaStatsByProfile(
+  List<MangaStatsEntry> stats,
+  String? profileId,
+) async {
+  if (profileId == null || stats.isEmpty) return stats;
+  final byMangaId = <int, String?>{};
+  final kept = <MangaStatsEntry>[];
+  for (final entry in stats) {
+    // Reading with no library entry cannot be attributed to a profile, so it
+    // is excluded from a profile-scoped view rather than counted everywhere.
+    if (entry.mangaId == 0) continue;
+    final resolved = byMangaId.putIfAbsent(entry.mangaId, () => null);
+    final profile =
+        resolved ??
+        await () async {
+          final manga = await isar.mangas.get(entry.mangaId);
+          final id = manga == null ? null : await _mangaProfileId(manga);
+          byMangaId[entry.mangaId] = id;
+          return id;
+        }();
+    if (profile == profileId) kept.add(entry);
+  }
+  return kept;
+}
+
+/// Chimahon treats an empty `profileId` as belonging to the first profile,
+/// because early builds wrote cards before profiles were introduced.
+List<AnkiStatsEntry> _filterAnkiByProfile(
+  List<AnkiStatsEntry> stats,
+  String? profileId,
+  List<DictionaryProfile> profiles,
+) {
+  if (profileId == null) return stats;
+  final firstProfileId = profiles.isEmpty ? null : profiles.first.id;
+  return stats
+      .where(
+        (entry) =>
+            entry.profileId == profileId ||
+            (entry.profileId.isEmpty && profileId == firstProfileId),
+      )
+      .toList();
+}
+
+// -------------------------------------------------------------- aggregations
+
+class _ChapterTotals {
+  const _ChapterTotals(this.total, this.read, this.downloaded);
+
+  final int total;
+  final int read;
+  final int downloaded;
+}
+
+Future<_ChapterTotals> _chapterTotals(
+  List<Manga> manga,
+  List<_NovelBook> novels,
+  ImmersionStatsType type,
+) async {
+  var total = 0;
+  var read = 0;
+  var downloaded = 0;
+  if (type != ImmersionStatsType.novels) {
+    for (final entry in manga) {
+      final id = entry.id;
+      if (id == null) continue;
+      total += await isar.chapters.filter().mangaIdEqualTo(id).count();
+      read += await isar.chapters
+          .filter()
+          .mangaIdEqualTo(id)
+          .isReadEqualTo(true)
+          .count();
+      downloaded += await isar.downloads
+          .filter()
+          .chapter((q) => q.mangaIdEqualTo(id))
+          .isDownloadEqualTo(true)
+          .count();
+    }
+  }
+  if (type != ImmersionStatsType.manga) {
+    // A novel's "chapters" are its EPUB spine entries; the parent library
+    // entry already holds one chapter row per spine item.
+    for (final book in novels) {
+      final parentId = book.mangaId;
+      if (parentId == null) continue;
+      total += await isar.chapters.filter().mangaIdEqualTo(parentId).count();
+      read += await isar.chapters
+          .filter()
+          .mangaIdEqualTo(parentId)
+          .isReadEqualTo(true)
+          .count();
+    }
+  }
+  return _ChapterTotals(total, read, downloaded);
+}
+
+int _completedCount(List<Manga> manga, ImmersionStatsType type) {
+  if (type == ImmersionStatsType.novels) return 0;
+  // Chimahon counts a title completed only when the source says it is finished
+  // and nothing is left unread.
+  return manga
+      .where(
+        (entry) =>
+            entry.status == Status.completed &&
+            entry.id != null &&
+            isar.chapters
+                    .filter()
+                    .mangaIdEqualTo(entry.id!)
+                    .isReadEqualTo(false)
+                    .countSync() ==
+                0 &&
+            isar.chapters.filter().mangaIdEqualTo(entry.id!).countSync() > 0,
+      )
+      .length;
+}
+
+Future<int> _startedCount(
+  List<Manga> manga,
+  List<_NovelBook> novels,
+  Map<String, List<NovelStatsEntry>> novelStats,
+  ImmersionStatsType type,
+) async {
+  var started = 0;
+  if (type != ImmersionStatsType.novels) {
+    for (final entry in manga) {
+      final id = entry.id;
+      if (id == null) continue;
+      final hasRead = await isar.chapters
+          .filter()
+          .mangaIdEqualTo(id)
+          .isReadEqualTo(true)
+          .count();
+      if (hasRead > 0) started++;
+    }
+  }
+  if (type != ImmersionStatsType.manga) {
+    // A novel counts as started once it has any recorded reading.
+    started += novels
+        .where((book) => (novelStats[book.chimahonId] ?? const []).isNotEmpty)
+        .length;
+  }
+  return started;
+}
+
+class _TrackerTotals {
+  const _TrackerTotals(this.trackedTitles, this.meanScore, this.trackerCount);
+
+  final int trackedTitles;
+  final double meanScore;
+  final int trackerCount;
+}
+
+Future<_TrackerTotals> _trackerTotals(List<Manga> manga) async {
+  final loggedIn = await isar.trackPreferences
+      .filter()
+      .syncIdIsNotNull()
+      .findAll();
+  final loggedInIds = {
+    for (final preference in loggedIn)
+      if (preference.syncId != null) preference.syncId!,
+  };
+  if (loggedInIds.isEmpty) return const _TrackerTotals(0, 0, 0);
+
+  final scoreScales = {
+    for (final preference in loggedIn)
+      if (preference.syncId != null)
+        preference.syncId!: _scoreScale(preference.syncId!),
+  };
+
+  var trackedTitles = 0;
+  final titleAverages = <double>[];
+  for (final entry in manga) {
+    final id = entry.id;
+    if (id == null) continue;
+    final tracks = (await isar.tracks.filter().mangaIdEqualTo(id).findAll())
+        .where((track) => loggedInIds.contains(track.syncId))
+        .toList();
+    if (tracks.isEmpty) continue;
+    trackedTitles++;
+    final scored = <double>[];
+    for (final track in tracks) {
+      final score = track.score ?? 0;
+      if (score <= 0) continue;
+      scored.add(_tenPointScore(score, scoreScales[track.syncId] ?? 10));
+    }
+    if (scored.isNotEmpty) {
+      titleAverages.add(scored.reduce((a, b) => a + b) / scored.length);
+    }
+  }
+
+  final meanScore = titleAverages.isEmpty
+      ? 0.0
+      : titleAverages.reduce((a, b) => a + b) / titleAverages.length;
+  return _TrackerTotals(trackedTitles, meanScore, loggedInIds.length);
+}
+
+/// The maximum raw score a tracker reports, used to normalize to 10 points.
+///
+/// AniList (syncId 2) always stores its score internally out of 100 regardless
+/// of the display format the account uses; every other tracker reports out of
+/// 10.
+int _scoreScale(int syncId) => syncId == 2 ? 100 : 10;
+
+double _tenPointScore(int score, int scale) =>
+    scale <= 0 ? 0 : score * 10 / scale;
+
+/// Consecutive days ending today (or yesterday) with any recorded reading.
+int _readingStreak(
+  List<MangaStatsEntry> mangaStats,
+  List<NovelStatsEntry> novelStats,
+) {
+  final days = <DateTime>{};
+  for (final entry in mangaStats) {
+    final date = parseStatsDateKey(entry.dateKey);
+    if (date != null) days.add(date);
+  }
+  for (final entry in novelStats) {
+    final date = parseStatsDateKey(entry.dateKey);
+    if (date != null) days.add(date);
+  }
+  if (days.isEmpty) return 0;
+
+  final now = DateTime.now();
+  var current = DateTime(now.year, now.month, now.day);
+  // Not having read yet today does not break a streak; it resumes from
+  // yesterday.
+  if (!days.contains(current)) {
+    current = current.subtract(const Duration(days: 1));
+  }
+  var streak = 0;
+  while (days.contains(current)) {
+    streak++;
+    current = current.subtract(const Duration(days: 1));
+  }
+  return streak;
+}
+
+/// The bars for the hero chart: a week of days, a month of weeks, a year of
+/// months, or the last five years.
+List<ImmersionHistoryPoint> _historyPoints({
+  required List<MangaStatsEntry> mangaStats,
+  required List<NovelStatsEntry> novelStats,
+  required ImmersionStatsDateScale scale,
+  required int offset,
+}) {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final range = immersionStatsDateRange(scale, offset, now: now);
+
+  int durationFor(DateTime start, DateTime end) {
+    final window = ImmersionStatsDateRange(start, end);
+    var total = 0;
+    for (final entry in mangaStats) {
+      if (window.containsKey(entry.dateKey)) total += entry.readingTimeMs;
+    }
+    for (final entry in novelStats) {
+      if (window.containsKey(entry.dateKey)) total += entry.readingTimeMs;
+    }
+    return total;
+  }
+
+  switch (scale) {
+    case ImmersionStatsDateScale.day:
+      final weekStart = range.start.subtract(
+        Duration(days: range.start.weekday - DateTime.monday),
+      );
+      return [
+        for (var i = 0; i < 7; i++)
+          () {
+            final date = weekStart.add(Duration(days: i));
+            return ImmersionHistoryPoint(
+              label: _weekdayLabels[date.weekday - 1],
+              durationMs: durationFor(date, date),
+              dateOffset: date.difference(today).inDays,
+            );
+          }(),
+      ];
+    case ImmersionStatsDateScale.week:
+      // Bars cover the weeks of the month the selected week falls in; the
+      // Thursday of an ISO week always lies inside its owning month.
+      final anchor = range.start.add(const Duration(days: 3));
+      final monthStart = DateTime(anchor.year, anchor.month);
+      final monthEnd = DateTime(anchor.year, anchor.month + 1, 0);
+      final firstMonday = monthStart.subtract(
+        Duration(days: monthStart.weekday - DateTime.monday),
+      );
+      final lastMonday = monthEnd.subtract(
+        Duration(days: monthEnd.weekday - DateTime.monday),
+      );
+      final weeks = (lastMonday.difference(firstMonday).inDays ~/ 7) + 1;
+      final currentMonday = today.subtract(
+        Duration(days: today.weekday - DateTime.monday),
+      );
+      return [
+        for (var i = 0; i < (weeks < 4 ? 4 : weeks); i++)
+          () {
+            final weekStart = firstMonday.add(Duration(days: i * 7));
+            final weekEnd = weekStart.add(const Duration(days: 6));
+            return ImmersionHistoryPoint(
+              label: 'W${_isoWeekNumber(weekStart)}',
+              durationMs: durationFor(weekStart, weekEnd),
+              dateOffset: weekStart.difference(currentMonday).inDays ~/ 7,
+            );
+          }(),
+      ];
+    case ImmersionStatsDateScale.month:
+      return [
+        for (var month = 1; month <= 12; month++)
+          () {
+            final start = DateTime(range.start.year, month);
+            final end = DateTime(range.start.year, month + 1, 0);
+            return ImmersionHistoryPoint(
+              label: _monthLabels[month - 1],
+              durationMs: durationFor(start, end),
+              dateOffset:
+                  (start.year - today.year) * 12 + (start.month - today.month),
+            );
+          }(),
+      ];
+    case ImmersionStatsDateScale.year:
+    case ImmersionStatsDateScale.allTime:
+      return [
+        for (var yearsAgo = 4; yearsAgo >= 0; yearsAgo--)
+          () {
+            final year = today.year - yearsAgo;
+            return ImmersionHistoryPoint(
+              label: year.toString(),
+              durationMs: durationFor(DateTime(year), DateTime(year, 12, 31)),
+              dateOffset: -yearsAgo,
+            );
+          }(),
+      ];
+  }
+}
+
+/// ISO-8601 week number, matching Chimahon's `WEEK_OF_WEEK_BASED_YEAR`.
+int _isoWeekNumber(DateTime date) {
+  final thursday = date.add(Duration(days: DateTime.thursday - date.weekday));
+  final firstThursday = DateTime(thursday.year, 1, 4);
+  final firstThursdayOfYear = firstThursday.add(
+    Duration(days: DateTime.thursday - firstThursday.weekday),
+  );
+  return 1 + thursday.difference(firstThursdayOfYear).inDays ~/ 7;
+}
+
+DateTime? _latestDate(Iterable<String> dateKeys) {
+  DateTime? latest;
+  for (final key in dateKeys) {
+    final date = parseStatsDateKey(key);
+    if (date == null) continue;
+    if (latest == null || date.isAfter(latest)) latest = date;
+  }
+  return latest;
+}
+
+const _weekdayLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const _monthLabels = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];

--- a/lib/modules/more/statistics/immersion_stats_provider.g.dart
+++ b/lib/modules/more/statistics/immersion_stats_provider.g.dart
@@ -1,0 +1,288 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'immersion_stats_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Aggregates immersion statistics for one filter combination.
+///
+/// This is the Dart counterpart of Chimahon's `StatsScreenModel`. Manga rows
+/// hold milliseconds and novel rows hold seconds, so every novel value is
+/// converted at the point of use rather than at load time — matching Chimahon
+/// and keeping the persisted schema byte-compatible.
+
+@ProviderFor(immersionStats)
+final immersionStatsProvider = ImmersionStatsFamily._();
+
+/// Aggregates immersion statistics for one filter combination.
+///
+/// This is the Dart counterpart of Chimahon's `StatsScreenModel`. Manga rows
+/// hold milliseconds and novel rows hold seconds, so every novel value is
+/// converted at the point of use rather than at load time — matching Chimahon
+/// and keeping the persisted schema byte-compatible.
+
+final class ImmersionStatsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<ImmersionStatsOverview>,
+          ImmersionStatsOverview,
+          FutureOr<ImmersionStatsOverview>
+        >
+    with
+        $FutureModifier<ImmersionStatsOverview>,
+        $FutureProvider<ImmersionStatsOverview> {
+  /// Aggregates immersion statistics for one filter combination.
+  ///
+  /// This is the Dart counterpart of Chimahon's `StatsScreenModel`. Manga rows
+  /// hold milliseconds and novel rows hold seconds, so every novel value is
+  /// converted at the point of use rather than at load time — matching Chimahon
+  /// and keeping the persisted schema byte-compatible.
+  ImmersionStatsProvider._({
+    required ImmersionStatsFamily super.from,
+    required ImmersionStatsQuery super.argument,
+  }) : super(
+         retry: null,
+         name: r'immersionStatsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$immersionStatsHash();
+
+  @override
+  String toString() {
+    return r'immersionStatsProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<ImmersionStatsOverview> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<ImmersionStatsOverview> create(Ref ref) {
+    final argument = this.argument as ImmersionStatsQuery;
+    return immersionStats(ref, query: argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ImmersionStatsProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$immersionStatsHash() => r'ae2f805c1dc163cd622340dcc23d23617cd20bce';
+
+/// Aggregates immersion statistics for one filter combination.
+///
+/// This is the Dart counterpart of Chimahon's `StatsScreenModel`. Manga rows
+/// hold milliseconds and novel rows hold seconds, so every novel value is
+/// converted at the point of use rather than at load time — matching Chimahon
+/// and keeping the persisted schema byte-compatible.
+
+final class ImmersionStatsFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<ImmersionStatsOverview>,
+          ImmersionStatsQuery
+        > {
+  ImmersionStatsFamily._()
+    : super(
+        retry: null,
+        name: r'immersionStatsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Aggregates immersion statistics for one filter combination.
+  ///
+  /// This is the Dart counterpart of Chimahon's `StatsScreenModel`. Manga rows
+  /// hold milliseconds and novel rows hold seconds, so every novel value is
+  /// converted at the point of use rather than at load time — matching Chimahon
+  /// and keeping the persisted schema byte-compatible.
+
+  ImmersionStatsProvider call({required ImmersionStatsQuery query}) =>
+      ImmersionStatsProvider._(argument: query, from: this);
+
+  @override
+  String toString() => r'immersionStatsProvider';
+}
+
+/// The per-title list backing the "In library" card drill-down.
+
+@ProviderFor(immersionStatsTitles)
+final immersionStatsTitlesProvider = ImmersionStatsTitlesFamily._();
+
+/// The per-title list backing the "In library" card drill-down.
+
+final class ImmersionStatsTitlesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<ImmersionStatsTitle>>,
+          List<ImmersionStatsTitle>,
+          FutureOr<List<ImmersionStatsTitle>>
+        >
+    with
+        $FutureModifier<List<ImmersionStatsTitle>>,
+        $FutureProvider<List<ImmersionStatsTitle>> {
+  /// The per-title list backing the "In library" card drill-down.
+  ImmersionStatsTitlesProvider._({
+    required ImmersionStatsTitlesFamily super.from,
+    required ({
+      ImmersionStatsQuery query,
+      ImmersionStatsTitlesSort sort,
+      String? search,
+    })
+    super.argument,
+  }) : super(
+         retry: null,
+         name: r'immersionStatsTitlesProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$immersionStatsTitlesHash();
+
+  @override
+  String toString() {
+    return r'immersionStatsTitlesProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<List<ImmersionStatsTitle>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<ImmersionStatsTitle>> create(Ref ref) {
+    final argument =
+        this.argument
+            as ({
+              ImmersionStatsQuery query,
+              ImmersionStatsTitlesSort sort,
+              String? search,
+            });
+    return immersionStatsTitles(
+      ref,
+      query: argument.query,
+      sort: argument.sort,
+      search: argument.search,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ImmersionStatsTitlesProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$immersionStatsTitlesHash() =>
+    r'5c97ca5fccf3abd372386adbae789b3fb353fa1c';
+
+/// The per-title list backing the "In library" card drill-down.
+
+final class ImmersionStatsTitlesFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<List<ImmersionStatsTitle>>,
+          ({
+            ImmersionStatsQuery query,
+            ImmersionStatsTitlesSort sort,
+            String? search,
+          })
+        > {
+  ImmersionStatsTitlesFamily._()
+    : super(
+        retry: null,
+        name: r'immersionStatsTitlesProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// The per-title list backing the "In library" card drill-down.
+
+  ImmersionStatsTitlesProvider call({
+    required ImmersionStatsQuery query,
+    required ImmersionStatsTitlesSort sort,
+    String? search,
+  }) => ImmersionStatsTitlesProvider._(
+    argument: (query: query, sort: sort, search: search),
+    from: this,
+  );
+
+  @override
+  String toString() => r'immersionStatsTitlesProvider';
+}
+
+/// Dictionary profiles available as a filter.
+
+@ProviderFor(immersionStatsProfiles)
+final immersionStatsProfilesProvider = ImmersionStatsProfilesProvider._();
+
+/// Dictionary profiles available as a filter.
+
+final class ImmersionStatsProfilesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<DictionaryProfile>>,
+          List<DictionaryProfile>,
+          FutureOr<List<DictionaryProfile>>
+        >
+    with
+        $FutureModifier<List<DictionaryProfile>>,
+        $FutureProvider<List<DictionaryProfile>> {
+  /// Dictionary profiles available as a filter.
+  ImmersionStatsProfilesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'immersionStatsProfilesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$immersionStatsProfilesHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<DictionaryProfile>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<DictionaryProfile>> create(Ref ref) {
+    return immersionStatsProfiles(ref);
+  }
+}
+
+String _$immersionStatsProfilesHash() =>
+    r'ea244dd8b8185e5cae12f3d73b9bac91e98f84be';

--- a/lib/modules/more/statistics/immersion_stats_screen.dart
+++ b/lib/modules/more/statistics/immersion_stats_screen.dart
@@ -1,0 +1,719 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mangayomi/modules/more/statistics/immersion_stats_data.dart';
+import 'package:mangayomi/modules/more/statistics/immersion_stats_provider.dart';
+import 'package:mangayomi/modules/more/statistics/widgets/immersion_stats_format.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+
+/// Chimahon's immersion statistics screen.
+///
+/// Passing [titleId] renders the single-title variant: library, tracker, and
+/// download metrics are hidden because they are not per-title values.
+class ImmersionStatsScreen extends ConsumerStatefulWidget {
+  const ImmersionStatsScreen({
+    super.key,
+    this.titleId,
+    this.isNovel = false,
+    this.titleName,
+  });
+
+  final String? titleId;
+  final bool isNovel;
+  final String? titleName;
+
+  @override
+  ConsumerState<ImmersionStatsScreen> createState() =>
+      _ImmersionStatsScreenState();
+}
+
+class _ImmersionStatsScreenState extends ConsumerState<ImmersionStatsScreen> {
+  late ImmersionStatsQuery _query;
+
+  bool get _isSingleTitle => widget.titleId != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _query = ImmersionStatsQuery(
+      titleId: widget.titleId,
+      isNovel: widget.isNovel,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = ref.watch(immersionStatsProvider(query: _query));
+    final profiles = ref
+        .watch(immersionStatsProfilesProvider)
+        .whenOrNull(data: (profiles) => profiles);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.titleName ?? 'Statistics'),
+        actions: [
+          if (!_isSingleTitle)
+            PopupMenuButton<void>(
+              itemBuilder: (context) => [
+                PopupMenuItem<void>(
+                  onTap: () => setState(
+                    () => _query = _query.copyWith(
+                      includeNonLibrary: !_query.includeNonLibrary,
+                    ),
+                  ),
+                  child: Text(
+                    _query.includeNonLibrary
+                        ? 'Ignore non-library entries'
+                        : 'Include all read entries',
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+      body: stats.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text('Err: $error')),
+        data: (overview) => ListView(
+          children: [
+            _FiltersRow(
+              query: _query,
+              profiles: profiles ?? const [],
+              isSingleTitle: _isSingleTitle,
+              onChanged: (query) => setState(() => _query = query),
+            ),
+            if (_query.scale != ImmersionStatsDateScale.allTime)
+              _DateNavigation(
+                query: _query,
+                onOffsetChange: (offset) =>
+                    setState(() => _query = _query.copyWith(offset: offset)),
+              ),
+            _HeroSection(
+              overview: overview,
+              selectedOffset: _query.offset,
+              onOffsetChange: (offset) =>
+                  setState(() => _query = _query.copyWith(offset: offset)),
+            ),
+            _StatsGrid(
+              overview: overview,
+              query: _query,
+              isSingleTitle: _isSingleTitle,
+              onLibraryTap: _isSingleTitle
+                  ? null
+                  : () => context.push('/statistics/titles', extra: _query),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FiltersRow extends StatelessWidget {
+  const _FiltersRow({
+    required this.query,
+    required this.profiles,
+    required this.isSingleTitle,
+    required this.onChanged,
+  });
+
+  final ImmersionStatsQuery query;
+  final List<dynamic> profiles;
+  final bool isSingleTitle;
+  final ValueChanged<ImmersionStatsQuery> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final activeProfile = profiles.cast<dynamic>().where(
+      (profile) => profile.id == query.profileId,
+    );
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.only(left: 16, right: 16, top: 4, bottom: 12),
+      child: Row(
+        spacing: 8,
+        children: [
+          if (!isSingleTitle)
+            for (final type in ImmersionStatsType.values)
+              FilterChip(
+                selected: query.type == type,
+                showCheckmark: false,
+                label: Text(immersionStatsTypeLabel(type)),
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(8)),
+                ),
+                // Switching scope invalidates the selected period's meaning as
+                // little as possible, so the offset is intentionally kept.
+                onSelected: (_) => onChanged(query.copyWith(type: type)),
+              ),
+          PopupMenuButton<ImmersionStatsDateScale>(
+            onSelected: (scale) =>
+                // A new scale reinterprets the offset units, so reset to the
+                // current period rather than jumping somewhere arbitrary.
+                onChanged(query.copyWith(scale: scale, offset: 0)),
+            itemBuilder: (context) => [
+              for (final scale in ImmersionStatsDateScale.values)
+                PopupMenuItem(
+                  value: scale,
+                  child: Text(immersionStatsScaleLabel(scale)),
+                ),
+            ],
+            child: _ChipShell(
+              label: immersionStatsScaleLabel(query.scale),
+              selected: false,
+            ),
+          ),
+          if (!isSingleTitle && profiles.isNotEmpty)
+            PopupMenuButton<String?>(
+              onSelected: (profileId) => onChanged(
+                profileId == null
+                    ? query.copyWith(clearProfileId: true)
+                    : query.copyWith(profileId: profileId),
+              ),
+              itemBuilder: (context) => [
+                const PopupMenuItem<String?>(child: Text('All profiles')),
+                for (final profile in profiles)
+                  PopupMenuItem<String?>(
+                    value: profile.id as String,
+                    child: Text(profile.name as String),
+                  ),
+              ],
+              child: _ChipShell(
+                label: activeProfile.isEmpty
+                    ? 'All profiles'
+                    : 'Profile: ${activeProfile.first.name}',
+                selected: query.profileId != null,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A chip that opens a menu rather than toggling, so it cannot use FilterChip's
+/// tap handling.
+class _ChipShell extends StatelessWidget {
+  const _ChipShell({required this.label, required this.selected});
+
+  final String label;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: selected ? theme.colorScheme.primaryContainer : null,
+        borderRadius: const BorderRadius.all(Radius.circular(8)),
+        border: Border.all(
+          color: selected
+              ? Colors.transparent
+              : theme.colorScheme.outline.withValues(alpha: 0.3),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: selected ? theme.colorScheme.onPrimaryContainer : null,
+            ),
+          ),
+          const Icon(Icons.arrow_drop_down, size: 18),
+        ],
+      ),
+    );
+  }
+}
+
+class _DateNavigation extends StatelessWidget {
+  const _DateNavigation({required this.query, required this.onOffsetChange});
+
+  final ImmersionStatsQuery query;
+  final ValueChanged<int> onOffsetChange;
+
+  @override
+  Widget build(BuildContext context) {
+    final canGoForward = query.offset < 0;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          IconButton(
+            onPressed: () => onOffsetChange(query.offset - 1),
+            icon: const Icon(Icons.chevron_left),
+          ),
+          Text(
+            immersionStatsPeriodLabel(query.scale, query.offset),
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          IconButton(
+            // The future holds no reading, so navigating past the current
+            // period is disabled rather than showing empty periods.
+            onPressed: canGoForward
+                ? () => onOffsetChange(query.offset + 1)
+                : null,
+            icon: const Icon(Icons.chevron_right),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Total time for the period, the per-day average, and a tappable bar chart.
+class _HeroSection extends StatelessWidget {
+  const _HeroSection({
+    required this.overview,
+    required this.selectedOffset,
+    required this.onOffsetChange,
+  });
+
+  final ImmersionStatsOverview overview;
+  final int selectedOffset;
+  final ValueChanged<int> onOffsetChange;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final duration = overview.totalReadDurationMs;
+    final hours = duration ~/ 3600000;
+    final minutes = (duration % 3600000) ~/ 60000;
+    final average = overview.avgDurationPerDayMs;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              if (hours > 0) ...[
+                Text(
+                  '$hours',
+                  style: const TextStyle(
+                    fontSize: 56,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 10, left: 2, right: 4),
+                  child: Text(
+                    'h',
+                    style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w500,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ],
+              Text(
+                '$minutes',
+                style: const TextStyle(
+                  fontSize: 56,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(bottom: 10, left: 2),
+                child: Text(
+                  'm',
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w500,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          SizedBox(
+            height: 48,
+            child: average == null
+                ? null
+                : Text(
+                    formatAveragePerDay(average),
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+          ),
+          _HistoryChart(
+            points: overview.historyPoints,
+            selectedOffset: selectedOffset,
+            onOffsetChange: onOffsetChange,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HistoryChart extends StatelessWidget {
+  const _HistoryChart({
+    required this.points,
+    required this.selectedOffset,
+    required this.onOffsetChange,
+  });
+
+  final List<ImmersionHistoryPoint> points;
+  final int selectedOffset;
+  final ValueChanged<int> onOffsetChange;
+
+  @override
+  Widget build(BuildContext context) {
+    if (points.isEmpty) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    final maxValue = points
+        .map((point) => point.durationMs)
+        .reduce((a, b) => a > b ? a : b);
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: SizedBox(
+            height: 120,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                for (final point in points)
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () => onOffsetChange(point.dateOffset),
+                      // A transparent hit area keeps short bars tappable.
+                      behavior: HitTestBehavior.opaque,
+                      child: Align(
+                        alignment: Alignment.bottomCenter,
+                        child: FractionallySizedBox(
+                          widthFactor: 0.5,
+                          child: Container(
+                            constraints: const BoxConstraints(minHeight: 4),
+                            height: maxValue > 0
+                                ? 120 * point.durationMs / maxValue
+                                : 4,
+                            decoration: BoxDecoration(
+                              color: point.dateOffset == selectedOffset
+                                  ? theme.colorScheme.primary
+                                  : theme.colorScheme.primary.withValues(
+                                      alpha: point.durationMs > 0 ? 0.3 : 0.15,
+                                    ),
+                              borderRadius: const BorderRadius.all(
+                                Radius.circular(6),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+          child: Row(
+            children: [
+              for (final point in points)
+                Expanded(
+                  child: Text(
+                    point.label,
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: point.dateOffset == selectedOffset
+                          ? theme.colorScheme.onSurface
+                          : theme.colorScheme.onSurfaceVariant.withValues(
+                              alpha: 0.5,
+                            ),
+                      fontWeight: point.dateOffset == selectedOffset
+                          ? FontWeight.bold
+                          : FontWeight.normal,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatsGrid extends StatelessWidget {
+  const _StatsGrid({
+    required this.overview,
+    required this.query,
+    required this.isSingleTitle,
+    this.onLibraryTap,
+  });
+
+  final ImmersionStatsOverview overview;
+  final ImmersionStatsQuery query;
+  final bool isSingleTitle;
+  final VoidCallback? onLibraryTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final showMangaOnlyMetrics =
+        query.type != ImmersionStatsType.novels && !isSingleTitle;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+      child: Column(
+        spacing: 24,
+        children: [
+          _MetricSection(
+            rows: [
+              [
+                _Metric(
+                  value: '${overview.readingStreak}',
+                  label: 'Streak',
+                  unit: 'day',
+                  icon: Icons.local_fire_department_outlined,
+                ),
+                _Metric(
+                  value: formatCount(overview.ankiCardsAdded),
+                  label: 'Added cards',
+                  icon: Icons.style_outlined,
+                ),
+              ],
+              [
+                _Metric(
+                  value: formatCount(overview.charactersRead),
+                  label: 'Characters read',
+                  icon: Icons.text_fields_outlined,
+                ),
+                _Metric(
+                  value: formatCount(overview.charactersPerHour ?? 0),
+                  label: 'Avg speed',
+                  unit: 'ch/h',
+                  icon: Icons.speed_outlined,
+                ),
+              ],
+            ],
+          ),
+          if (!isSingleTitle)
+            _MetricSection(
+              title: 'Library',
+              rows: [
+                [
+                  _Metric(
+                    value: formatCount(overview.libraryTitleCount),
+                    label: query.includeNonLibrary ? 'All read' : 'In library',
+                    icon: Icons.library_books_outlined,
+                    onTap: onLibraryTap,
+                  ),
+                  _Metric(
+                    value: formatCount(overview.localTitleCount),
+                    label: 'Local',
+                    icon: Icons.sd_card_outlined,
+                  ),
+                ],
+                [
+                  _Metric(
+                    value: formatCount(overview.startedTitleCount),
+                    label: 'Started',
+                    icon: Icons.play_arrow_outlined,
+                  ),
+                  _Metric(
+                    value: formatCount(overview.completedTitleCount),
+                    label: 'Completed',
+                    icon: Icons.done_all_outlined,
+                  ),
+                ],
+              ],
+            ),
+          _MetricSection(
+            title: 'Chapters',
+            rows: [
+              [
+                _Metric(
+                  value: formatCount(overview.totalChapterCount),
+                  label: 'Total',
+                  icon: Icons.menu_book_outlined,
+                ),
+                _Metric(
+                  value: formatCount(overview.readChapterCount),
+                  label: 'Read',
+                  icon: Icons.history_outlined,
+                ),
+              ],
+              if (showMangaOnlyMetrics)
+                [
+                  _Metric(
+                    value: formatCount(overview.downloadedChapterCount),
+                    label: 'Downloaded',
+                    icon: Icons.download_outlined,
+                  ),
+                ],
+            ],
+          ),
+          if (showMangaOnlyMetrics)
+            _MetricSection(
+              title: 'Trackers',
+              rows: [
+                [
+                  _Metric(
+                    value: formatCount(overview.trackedTitleCount),
+                    label: 'Tracked titles',
+                    icon: Icons.collections_bookmark_outlined,
+                  ),
+                  _Metric(
+                    value: overview.meanScore > 0
+                        ? overview.meanScore.toStringAsFixed(1)
+                        : '0.0',
+                    label: 'Mean score',
+                    icon: Icons.star_outline,
+                  ),
+                ],
+                [
+                  _Metric(
+                    value: formatCount(overview.trackerCount),
+                    label: 'Trackers',
+                    icon: Icons.public_outlined,
+                  ),
+                ],
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetricSection extends StatelessWidget {
+  const _MetricSection({this.title, required this.rows});
+
+  final String? title;
+  final List<List<_Metric>> rows;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      spacing: 12,
+      children: [
+        if (title != null)
+          Padding(
+            padding: const EdgeInsets.only(left: 4),
+            child: Text(
+              title!,
+              style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                color: context.primaryColor,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        for (final row in rows)
+          Row(
+            spacing: 12,
+            children: [
+              for (final metric in row) Expanded(child: metric),
+              // Pad a short row so a lone card keeps the grid's column width.
+              if (row.length == 1) const Spacer(),
+            ],
+          ),
+      ],
+    );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  const _Metric({
+    required this.value,
+    required this.label,
+    required this.icon,
+    this.unit,
+    this.onTap,
+  });
+
+  final String value;
+  final String label;
+  final IconData icon;
+  final String? unit;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+      borderRadius: const BorderRadius.all(Radius.circular(24)),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(Radius.circular(24)),
+        child: SizedBox(
+          height: 114,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Icon(icon, size: 24, color: context.primaryColor),
+                    if (onTap != null)
+                      Icon(
+                        Icons.chevron_right,
+                        size: 20,
+                        color: theme.colorScheme.onSurfaceVariant.withValues(
+                          alpha: 0.6,
+                        ),
+                      ),
+                  ],
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      spacing: 4,
+                      children: [
+                        Flexible(
+                          child: Text(
+                            value,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.titleLarge?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        if (unit != null)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 2),
+                            child: Text(
+                              unit!,
+                              style: theme.textTheme.labelMedium?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                    Text(
+                      label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.labelMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/more/statistics/immersion_stats_titles_screen.dart
+++ b/lib/modules/more/statistics/immersion_stats_titles_screen.dart
@@ -1,0 +1,246 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/modules/more/statistics/immersion_stats_data.dart';
+import 'package:mangayomi/modules/more/statistics/immersion_stats_provider.dart';
+import 'package:mangayomi/modules/more/statistics/widgets/immersion_stats_format.dart';
+import 'package:mangayomi/utils/cached_network.dart';
+import 'package:mangayomi/utils/constant.dart';
+import 'package:mangayomi/utils/headers.dart';
+
+/// The drill-down from the "In library" card: every title with its recorded
+/// reading, searchable and sortable, opening a single-title stats view.
+class ImmersionStatsTitlesScreen extends ConsumerStatefulWidget {
+  const ImmersionStatsTitlesScreen({super.key, required this.query});
+
+  final ImmersionStatsQuery query;
+
+  @override
+  ConsumerState<ImmersionStatsTitlesScreen> createState() =>
+      _ImmersionStatsTitlesScreenState();
+}
+
+class _ImmersionStatsTitlesScreenState
+    extends ConsumerState<ImmersionStatsTitlesScreen> {
+  final _searchController = TextEditingController();
+  var _sort = ImmersionStatsTitlesSort.lastRead;
+  var _searching = false;
+  String? _search;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final titles = ref.watch(
+      immersionStatsTitlesProvider(
+        query: widget.query,
+        sort: _sort,
+        search: _search,
+      ),
+    );
+    final scopeLabel = widget.query.includeNonLibrary
+        ? 'All read'
+        : 'In library';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: _searching
+            ? TextField(
+                controller: _searchController,
+                autofocus: true,
+                decoration: const InputDecoration(
+                  border: InputBorder.none,
+                  hintText: 'Search',
+                ),
+                onChanged: (value) => setState(() => _search = value),
+              )
+            : Text('Statistics - $scopeLabel'),
+        actions: [
+          IconButton(
+            icon: Icon(_searching ? Icons.close : Icons.search),
+            onPressed: () => setState(() {
+              _searching = !_searching;
+              if (!_searching) {
+                _searchController.clear();
+                _search = null;
+              }
+            }),
+          ),
+          PopupMenuButton<ImmersionStatsTitlesSort>(
+            icon: const Icon(Icons.sort),
+            onSelected: (sort) => setState(() => _sort = sort),
+            itemBuilder: (context) => [
+              for (final sort in ImmersionStatsTitlesSort.values)
+                PopupMenuItem(
+                  value: sort,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(_sortLabel(sort)),
+                      if (_sort == sort) const Icon(Icons.check, size: 18),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+      body: titles.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text('Err: $error')),
+        data: (items) => items.isEmpty
+            ? const Center(child: Text('No titles found matching this filter.'))
+            : ListView.builder(
+                itemCount: items.length,
+                itemBuilder: (context, index) => _TitleTile(
+                  item: items[index],
+                  onTap: () => context.push(
+                    '/statistics/title',
+                    extra: items[index],
+                  ),
+                ),
+              ),
+      ),
+    );
+  }
+
+  static String _sortLabel(ImmersionStatsTitlesSort sort) => switch (sort) {
+    ImmersionStatsTitlesSort.alphabetical => 'Alphabetically',
+    ImmersionStatsTitlesSort.lastRead => 'Last read',
+    ImmersionStatsTitlesSort.dateAdded => 'Date added',
+  };
+}
+
+class _TitleTile extends ConsumerWidget {
+  const _TitleTile({required this.item, required this.onTap});
+
+  final ImmersionStatsTitle item;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: SizedBox(
+          height: 80,
+          child: Row(
+            children: [
+              ClipRRect(
+                borderRadius: const BorderRadius.all(Radius.circular(4)),
+                child: SizedBox(
+                  width: 56,
+                  height: 80,
+                  child: _Cover(mangaId: item.mangaId),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      item.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (item.author?.isNotEmpty == true)
+                      Text(
+                        item.author!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        _subtitle(item),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant.withValues(
+                            alpha: 0.8,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Reading time when there is any, else the last-read date, else unread.
+  static String _subtitle(ImmersionStatsTitle item) {
+    if (item.readDurationMs > 0) {
+      final duration = formatShortDuration(item.readDurationMs);
+      if (item.charactersRead > 0) {
+        return '$duration read • ${formatCount(item.charactersRead)} characters';
+      }
+      return '$duration read';
+    }
+    if (item.lastReadDate != null) {
+      return 'Last read: ${formatStatsDate(item.lastReadDate!)}';
+    }
+    return 'Unread';
+  }
+}
+
+class _Cover extends ConsumerWidget {
+  const _Cover({this.mangaId});
+
+  final int? mangaId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final placeholder = ColoredBox(
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: const Center(child: Icon(Icons.book_outlined, size: 20)),
+    );
+    final id = mangaId;
+    if (id == null) return placeholder;
+    final manga = isar.mangas.getSync(id);
+    if (manga == null) return placeholder;
+    if (manga.customCoverImage != null) {
+      return Image.memory(
+        manga.customCoverImage as Uint8List,
+        fit: BoxFit.cover,
+      );
+    }
+    final imageUrl = manga.customCoverFromTracker ?? manga.imageUrl ?? '';
+    if (imageUrl.isEmpty || manga.source == null || manga.lang == null) {
+      return placeholder;
+    }
+    return cachedCompressedNetworkImage(
+      headers: ref.watch(
+        headersProvider(
+          source: manga.source!,
+          lang: manga.lang!,
+          sourceId: manga.sourceId,
+        ),
+      ),
+      imageUrl: toImgUrl(imageUrl),
+      width: 56,
+      height: 80,
+      fit: BoxFit.cover,
+    );
+  }
+}

--- a/lib/modules/more/statistics/widgets/immersion_stats_format.dart
+++ b/lib/modules/more/statistics/widgets/immersion_stats_format.dart
@@ -1,0 +1,139 @@
+import 'package:mangayomi/modules/more/statistics/immersion_stats_data.dart';
+
+/// Formatting shared by the statistics screens and the in-reader sheets.
+///
+/// Chimahon's exact output is reproduced, including the two different duration
+/// formats it uses: `h:mm:ss` for elapsed reading and `Xh Ym Zs` for estimates.
+
+/// Groups thousands with commas, matching Chimahon's `toCountString`.
+String formatCount(int value) {
+  final digits = value.abs().toString();
+  final buffer = StringBuffer();
+  for (var i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) buffer.write(',');
+    buffer.write(digits[i]);
+  }
+  return value < 0 ? '-$buffer' : buffer.toString();
+}
+
+/// `h:mm:ss`, dropping the hour component when there is none.
+String formatElapsed(Duration duration) {
+  final totalSeconds = duration.inSeconds < 0 ? 0 : duration.inSeconds;
+  final seconds = totalSeconds % 60;
+  final minutes = (totalSeconds ~/ 60) % 60;
+  final hours = totalSeconds ~/ 3600;
+  final paddedSeconds = seconds.toString().padLeft(2, '0');
+  if (hours > 0) {
+    return '$hours:${minutes.toString().padLeft(2, '0')}:$paddedSeconds';
+  }
+  return '${minutes.toString().padLeft(2, '0')}:$paddedSeconds';
+}
+
+/// `Xh Ym Zs`, omitting leading zero components. Used for ETAs.
+String formatEstimate(double seconds) {
+  final totalSeconds = seconds.isFinite && seconds > 0 ? seconds.toInt() : 0;
+  final hours = totalSeconds ~/ 3600;
+  final minutes = (totalSeconds % 3600) ~/ 60;
+  final remaining = totalSeconds % 60;
+  if (hours > 0) return '${hours}h ${minutes}m ${remaining}s';
+  if (minutes > 0) return '${minutes}m ${remaining}s';
+  return '${remaining}s';
+}
+
+/// `Xh Ym per day` for the hero subtitle.
+String formatAveragePerDay(int durationMs) {
+  final hours = durationMs ~/ 3600000;
+  final minutes = (durationMs % 3600000) ~/ 60000;
+  return hours > 0 ? '${hours}h ${minutes}m per day' : '${minutes}m per day';
+}
+
+/// `Xh Ym` for the compact per-title duration.
+String formatShortDuration(int durationMs) {
+  final hours = durationMs ~/ 3600000;
+  final minutes = (durationMs % 3600000) ~/ 60000;
+  return hours > 0 ? '${hours}h ${minutes}m' : '${minutes}m';
+}
+
+String immersionStatsTypeLabel(ImmersionStatsType type) => switch (type) {
+  ImmersionStatsType.all => 'All',
+  ImmersionStatsType.manga => 'Manga',
+  ImmersionStatsType.novels => 'Novels',
+};
+
+String immersionStatsScaleLabel(ImmersionStatsDateScale scale) =>
+    switch (scale) {
+      ImmersionStatsDateScale.day => 'Day',
+      ImmersionStatsDateScale.week => 'Week',
+      ImmersionStatsDateScale.month => 'Month',
+      ImmersionStatsDateScale.year => 'Year',
+      ImmersionStatsDateScale.allTime => 'All Time',
+    };
+
+/// The heading above the chart: relative wording for the current and previous
+/// period, an explicit date otherwise.
+String immersionStatsPeriodLabel(
+  ImmersionStatsDateScale scale,
+  int offset, {
+  DateTime? now,
+}) {
+  final today = now ?? DateTime.now();
+  switch (scale) {
+    case ImmersionStatsDateScale.day:
+      if (offset == 0) return 'Today';
+      if (offset == -1) return 'Yesterday';
+      final date = immersionStatsDateRange(scale, offset, now: today).start;
+      return '${_monthNames[date.month - 1]} ${date.day}';
+    case ImmersionStatsDateScale.week:
+      if (offset == 0) return 'This week';
+      if (offset == -1) return 'Last week';
+      final range = immersionStatsDateRange(scale, offset, now: today);
+      final start = '${_monthNames[range.start.month - 1]} ${range.start.day}';
+      final end = '${_monthNames[range.end.month - 1]} ${range.end.day}';
+      return '$start - $end';
+    case ImmersionStatsDateScale.month:
+      if (offset == 0) return 'This month';
+      if (offset == -1) return 'Last month';
+      final date = immersionStatsDateRange(scale, offset, now: today).start;
+      return '${_fullMonthNames[date.month - 1]} ${date.year}';
+    case ImmersionStatsDateScale.year:
+      if (offset == 0) return 'This year';
+      if (offset == -1) return 'Last year';
+      return '${today.year + offset}';
+    case ImmersionStatsDateScale.allTime:
+      return 'All Time';
+  }
+}
+
+/// `MMM d, yyyy`, used for a title's last-read date.
+String formatStatsDate(DateTime date) =>
+    '${_monthNames[date.month - 1]} ${date.day}, ${date.year}';
+
+const _monthNames = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+const _fullMonthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];

--- a/lib/modules/more/statistics/widgets/manga_stats_sheet.dart
+++ b/lib/modules/more/statistics/widgets/manga_stats_sheet.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:mangayomi/modules/more/statistics/widgets/immersion_stats_format.dart';
+import 'package:mangayomi/modules/more/statistics/widgets/stats_sheet_layout.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_storage.dart';
+import 'package:mangayomi/services/statistics/manga_statistics_tracker.dart';
+
+/// Chimahon's in-reader manga statistics sheet.
+///
+/// Session values come from the live tracker; today and all-time are read from
+/// storage so they include reading from earlier sessions.
+class MangaStatsSheet extends StatefulWidget {
+  const MangaStatsSheet({
+    super.key,
+    required this.mangaId,
+    required this.session,
+    this.estimate = const MangaStatsEstimate(),
+    this.onToggleTracking,
+  });
+
+  final int mangaId;
+  final MangaStatisticsSession session;
+  final MangaStatsEstimate estimate;
+
+  /// Null hides the session section and pause control, for contexts outside the
+  /// reader (such as the library entry's stats action).
+  final VoidCallback? onToggleTracking;
+
+  @override
+  State<MangaStatsSheet> createState() => _MangaStatsSheetState();
+}
+
+class _MangaStatsSheetState extends State<MangaStatsSheet> {
+  var _today = const _Totals();
+  var _allTime = const _Totals();
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final stats = await ImmersionStatsStorage.loadMangaStats();
+    final todayKey = statsDateKey(DateTime.now());
+    final forManga = stats.where((entry) => entry.mangaId == widget.mangaId);
+    final today = forManga.where((entry) => entry.dateKey == todayKey);
+    if (!mounted) return;
+    setState(() {
+      _today = _Totals.from(today);
+      _allTime = _Totals.from(forManga);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showSession = widget.onToggleTracking != null;
+    final session = widget.session;
+    return StatsSheetLayout(
+      title: 'Statistics',
+      isTracking: showSession ? session.isTracking : null,
+      onToggleTracking: widget.onToggleTracking,
+      sections: [
+        if (showSession)
+          StatsSheetSection(
+            title: 'Session',
+            rows: [
+              StatsSheetRow('Characters Read', formatCount(session.charactersRead)),
+              StatsSheetRow('Reading Speed', '${session.charactersPerHour} /h'),
+              StatsSheetRow(
+                'Reading Time',
+                formatElapsed(Duration(milliseconds: session.readingTimeMs)),
+              ),
+              StatsSheetRow(
+                'Time to finish Book',
+                formatEstimate(widget.estimate.remainingBookSeconds),
+              ),
+              StatsSheetRow(
+                'Time to finish Chapter',
+                formatEstimate(widget.estimate.remainingChapterSeconds),
+              ),
+            ],
+          ),
+        StatsSheetSection(
+          title: 'Today',
+          rows: [
+            StatsSheetRow('Characters Read', formatCount(_today.characters)),
+            StatsSheetRow('Reading Speed', '${_today.charactersPerHour} /h'),
+            StatsSheetRow(
+              'Reading Time',
+              formatElapsed(Duration(milliseconds: _today.timeMs)),
+            ),
+          ],
+        ),
+        StatsSheetSection(
+          title: 'All Time',
+          rows: [
+            StatsSheetRow('Characters Read', formatCount(_allTime.characters)),
+            StatsSheetRow('Reading Speed', '${_allTime.charactersPerHour} /h'),
+            StatsSheetRow(
+              'Reading Time',
+              formatElapsed(Duration(milliseconds: _allTime.timeMs)),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _Totals {
+  const _Totals({this.characters = 0, this.timeMs = 0});
+
+  factory _Totals.from(Iterable<MangaStatsEntry> entries) {
+    var characters = 0;
+    var timeMs = 0;
+    for (final entry in entries) {
+      characters += entry.charactersRead;
+      timeMs += entry.readingTimeMs;
+    }
+    return _Totals(characters: characters, timeMs: timeMs);
+  }
+
+  final int characters;
+  final int timeMs;
+
+  int get charactersPerHour =>
+      timeMs > 0 ? (characters / (timeMs / 3600000)).toInt() : 0;
+}

--- a/lib/modules/more/statistics/widgets/novel_stats_sheet.dart
+++ b/lib/modules/more/statistics/widgets/novel_stats_sheet.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:mangayomi/modules/more/statistics/widgets/immersion_stats_format.dart';
+import 'package:mangayomi/modules/more/statistics/widgets/stats_sheet_layout.dart';
+import 'package:mangayomi/services/statistics/manga_statistics_tracker.dart';
+import 'package:mangayomi/services/statistics/novel_statistics_tracker.dart';
+
+/// Chimahon's in-reader novel statistics sheet.
+///
+/// The tracker already maintains session, today, and all-time buckets, so this
+/// only formats them and computes the two projections.
+class NovelStatsSheet extends StatelessWidget {
+  const NovelStatsSheet({
+    super.key,
+    required this.tracker,
+    required this.currentCharacter,
+    required this.totalCharacters,
+    required this.chapterEndCharacter,
+    required this.onToggleTracking,
+  });
+
+  final NovelStatisticsTracker tracker;
+
+  /// Live reader position, used for projections while tracking.
+  final int currentCharacter;
+  final int totalCharacters;
+  final int chapterEndCharacter;
+  final VoidCallback onToggleTracking;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = tracker.state;
+    final session = state.session;
+    // While paused, project from the frozen position so page flips during the
+    // pause do not move the estimate.
+    final projectionCharacter = state.isTracking
+        ? currentCharacter
+        : tracker.frozenPosition;
+
+    return StatsSheetLayout(
+      title: 'Statistics',
+      isTracking: state.isTracking,
+      onToggleTracking: onToggleTracking,
+      sections: [
+        StatsSheetSection(
+          title: 'Session',
+          rows: [
+            StatsSheetRow('Characters Read', formatCount(session.charactersRead)),
+            StatsSheetRow('Reading Speed', '${session.lastReadingSpeed} / h'),
+            StatsSheetRow(
+              'Reading Time',
+              formatElapsed(Duration(seconds: session.readingTimeSeconds.toInt())),
+            ),
+            StatsSheetRow(
+              'Time to finish Book',
+              formatEstimate(
+                MangaStatsEstimate.secondsRemaining(
+                  totalCharacters - projectionCharacter,
+                  session.lastReadingSpeed,
+                ),
+              ),
+            ),
+            StatsSheetRow(
+              'Time to finish Chapter',
+              formatEstimate(
+                MangaStatsEstimate.secondsRemaining(
+                  chapterEndCharacter - projectionCharacter,
+                  session.lastReadingSpeed,
+                ),
+              ),
+            ),
+          ],
+        ),
+        StatsSheetSection(
+          title: 'Today',
+          rows: _totalsRows(state.today.charactersRead,
+              state.today.lastReadingSpeed, state.today.readingTimeSeconds),
+        ),
+        StatsSheetSection(
+          title: 'All Time',
+          rows: _totalsRows(state.allTime.charactersRead,
+              state.allTime.lastReadingSpeed, state.allTime.readingTimeSeconds),
+        ),
+      ],
+    );
+  }
+
+  static List<StatsSheetRow> _totalsRows(
+    int characters,
+    int speed,
+    double seconds,
+  ) => [
+    StatsSheetRow('Characters Read', formatCount(characters)),
+    StatsSheetRow('Reading Speed', '$speed / h'),
+    StatsSheetRow('Reading Time', formatElapsed(Duration(seconds: seconds.toInt()))),
+  ];
+}

--- a/lib/modules/more/statistics/widgets/stats_sheet_layout.dart
+++ b/lib/modules/more/statistics/widgets/stats_sheet_layout.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+
+/// One label/value pair in a statistics sheet.
+class StatsSheetRow {
+  const StatsSheetRow(this.label, this.value);
+
+  final String label;
+  final String value;
+}
+
+/// A titled group of rows.
+class StatsSheetSection {
+  const StatsSheetSection({required this.title, required this.rows});
+
+  final String title;
+  final List<StatsSheetRow> rows;
+}
+
+/// Shared chrome for the in-reader statistics sheets, matching Chimahon's
+/// layout: a heading with an optional pause toggle above titled sections of
+/// label/value rows.
+class StatsSheetLayout extends StatelessWidget {
+  const StatsSheetLayout({
+    super.key,
+    required this.title,
+    required this.sections,
+    this.isTracking,
+    this.onToggleTracking,
+  });
+
+  final String title;
+  final List<StatsSheetSection> sections;
+
+  /// Null hides the toggle entirely.
+  final bool? isTracking;
+  final VoidCallback? onToggleTracking;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          spacing: 24,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(title, style: theme.textTheme.headlineSmall),
+                if (onToggleTracking != null)
+                  IconButton(
+                    onPressed: onToggleTracking,
+                    tooltip: isTracking == true ? 'Pause timer' : 'Resume timer',
+                    icon: Icon(
+                      isTracking == true ? Icons.pause : Icons.play_arrow,
+                    ),
+                  ),
+              ],
+            ),
+            for (final section in sections)
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                spacing: 16,
+                children: [
+                  Text(
+                    section.title,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: context.primaryColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    spacing: 12,
+                    children: [
+                      for (final row in section.rows)
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              row.label,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                            Text(
+                              row.value,
+                              style: theme.textTheme.bodyLarge?.copyWith(
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ],
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/novel/novel_reader_view.dart
+++ b/lib/modules/novel/novel_reader_view.dart
@@ -20,7 +20,11 @@ import 'package:mangayomi/modules/mining/reader_lookup_trigger.dart';
 import 'package:mangayomi/modules/mining/widgets/dictionary_lookup_popup.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/modules/novel/novel_reader_controller_provider.dart';
+import 'package:mangayomi/modules/more/statistics/widgets/novel_stats_sheet.dart';
 import 'package:mangayomi/modules/novel/novel_reader_progress.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_storage.dart';
+import 'package:mangayomi/services/statistics/novel_statistics_tracker.dart';
+import 'package:mangayomi/services/sync/chimahon_novel_progress_adapter.dart';
 import 'package:mangayomi/modules/novel/tts/novel_tts_service.dart';
 import 'package:mangayomi/modules/novel/tts/tts_player_bar.dart';
 import 'package:mangayomi/modules/novel/tts/tts_settings_tab.dart';
@@ -323,6 +327,7 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
         );
       }
     }
+    _trackStatsProgress();
     _progressPersistDebounce?.cancel();
     _progressPersistDebounce = Timer(const Duration(seconds: 2), () {
       if (!_isDisposed) {
@@ -342,6 +347,116 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
     );
   }
 
+  /// Resolves this book's Chimahon identity and loads its stored statistics.
+  Future<void> _initStatsTracker() async {
+    final progress = _statsBookProgress();
+    // A book with no Chimahon-representable identity cannot be persisted
+    // against; tracking is disabled rather than writing rows that would be
+    // dropped on the next sync.
+    final novelId = progress == null
+        ? null
+        : const ChimahonNovelProgressAdapter().stableLocalIdOrNull(progress);
+    if (novelId == null) return;
+    final stored = await ImmersionStatsStorage.loadNovelStats(novelId);
+    if (!mounted || _isDisposed) return;
+    final tracker = NovelStatisticsTracker(
+      novelId: novelId,
+      initialStatistics: stored,
+    );
+    // Anchor at the restored position so the first tick does not credit the
+    // whole book's offset as characters read in this session.
+    tracker.start(_epubCharacterCount ?? 0);
+    _statsTracker = tracker;
+    _statsSheetRevision.value++;
+  }
+
+  /// Computes the book's total character count and the current chapter's end
+  /// offset, both in Chimahon's explored-character space.
+  void _updateStatsCharacterBounds(EpubNovel book) {
+    final starts = epubCharacterStartsBySpine(book);
+    var total = 0;
+    for (final entry in book.chapters) {
+      if (entry.isLinear) {
+        total += chimahonChapterCharacterCount(entry.content);
+      }
+    }
+    _statsTotalCharacters = total;
+
+    final currentSpine =
+        _currentEpubSpineIndex ??
+        widget.initialEpubSpineIndex ??
+        epubChapterSpineIndex(chapter);
+    if (currentSpine == null) {
+      _statsChapterEndCharacter = total;
+      return;
+    }
+    // The chapter ends where the next linear spine item begins; the last
+    // chapter ends at the book's total.
+    final laterStarts = starts.entries
+        .where((entry) => entry.key > currentSpine)
+        .map((entry) => entry.value)
+        .toList();
+    _statsChapterEndCharacter = laterStarts.isEmpty
+        ? total
+        : laterStarts.reduce((a, b) => a < b ? a : b);
+  }
+
+  EpubBookProgress? _statsBookProgress() {
+    final mangaId = chapter.mangaId;
+    if (mangaId == null) return null;
+    final archivePath = chapter.archivePath;
+    final query = isar.epubBookProgress.filter().mangaIdEqualTo(mangaId);
+    return archivePath == null || archivePath.isEmpty
+        ? query.findFirstSync()
+        : query.archivePathEqualTo(archivePath).findFirstSync();
+  }
+
+  /// Feeds the reader's absolute character position to the tracker.
+  void _trackStatsProgress() {
+    final tracker = _statsTracker;
+    if (tracker == null) return;
+    tracker.update(_epubCharacterCount ?? 0);
+    if (_statsSheetOpen) _statsSheetRevision.value++;
+  }
+
+  bool _statsSheetOpen = false;
+
+  /// Opens the immersion statistics sheet for this book.
+  Future<void> _showStatsSheet() async {
+    final tracker = _statsTracker;
+    if (tracker == null) {
+      // The book has no Chimahon-representable identity, so nothing can be
+      // recorded against it.
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Statistics are unavailable for this book'),
+        ),
+      );
+      return;
+    }
+    _trackStatsProgress();
+    _statsSheetOpen = true;
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => ValueListenableBuilder<int>(
+        valueListenable: _statsSheetRevision,
+        builder: (context, _, _) => NovelStatsSheet(
+          tracker: tracker,
+          currentCharacter: _epubCharacterCount ?? 0,
+          totalCharacters: _statsTotalCharacters,
+          chapterEndCharacter: _statsChapterEndCharacter,
+          onToggleTracking: () {
+            tracker.togglePause(_epubCharacterCount ?? 0);
+            _statsSheetRevision.value++;
+          },
+        ),
+      ),
+    );
+    _statsSheetOpen = false;
+  }
+
   @override
   void dispose() {
     _isDisposed = true;
@@ -355,6 +470,12 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
         elapsedSeconds: _readingStopwatch.elapsed.inSeconds,
       );
     }
+    final statsTracker = _statsTracker;
+    if (statsTracker != null) {
+      statsTracker.stop(_epubCharacterCount ?? 0);
+      unawaited(statsTracker.persist());
+    }
+    _statsSheetRevision.dispose();
     _scrollController.removeListener(onScroll);
     _scrollController.dispose();
     _progressPersistDebounce?.cancel();
@@ -386,9 +507,17 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
       _appIsActive = false;
       _readingStopwatch.stop();
       if (!_epubPositionLocked) _persistProgress();
+      // Backgrounded time is not reading time, so close the tick window and
+      // flush what has accumulated.
+      final statsTracker = _statsTracker;
+      if (statsTracker != null) {
+        statsTracker.pause(_epubCharacterCount ?? 0);
+        unawaited(statsTracker.persist());
+      }
     } else if (state == AppLifecycleState.resumed) {
       _appIsActive = true;
       if (!_epubPositionLocked) _readingStopwatch.start();
+      _statsTracker?.start(_epubCharacterCount ?? 0);
     }
   }
 
@@ -397,9 +526,26 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
 
   final StreamController<double> _rebuildDetail =
       StreamController<double>.broadcast();
+
+  /// Chimahon-compatible immersion statistics for this book.
+  ///
+  /// Created lazily in [initState] because it needs the persisted rows, which
+  /// are loaded asynchronously; until then reader ticks are simply dropped.
+  NovelStatisticsTracker? _statsTracker;
+
+  /// Rebuilt while the statistics sheet is open so its values stay live.
+  final ValueNotifier<int> _statsSheetRevision = ValueNotifier(0);
+
+  /// Total characters in the whole book, for the time-to-finish projection.
+  int _statsTotalCharacters = 0;
+
+  /// Character offset at which the current chapter ends.
+  int _statsChapterEndCharacter = 0;
+
   @override
   void initState() {
     super.initState();
+    unawaited(_initStatsTracker());
     HardwareKeyboard.instance.addHandler(_handleHiddenEpubEscape);
     unawaited(ReaderLookupTriggerState.initialize());
     _epubLayout.addListener(_onEpubLayoutChanged);
@@ -830,6 +976,7 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
                 epubBook = data.$2;
                 if (epubBook != null) {
                   _initializeSavedEpubSpine(epubBook!);
+                  _updateStatsCharacterBounds(epubBook!);
                 }
                 _currentHtmlContent = data.$1;
                 final chapterCharacterCount = _usingTtsuReader
@@ -1642,6 +1789,7 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
         setState(() => _isBookmarked = !_isBookmarked);
       },
       onChapterSelected: _usingTtsuReader ? _selectEpubChapter : null,
+      onStatsPressed: _showStatsSheet,
       onWebViewPressed: (chapter.manga.value!.isLocalArchive ?? false)
           ? null
           : () async {

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -31,6 +31,9 @@ import 'package:mangayomi/modules/more/settings/player/player_decoder_screen.dar
 import 'package:mangayomi/modules/more/settings/player/player_overview_screen.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/modules/mining/widgets/dictionary_lookup_popup.dart';
+import 'package:mangayomi/modules/more/statistics/immersion_stats_data.dart';
+import 'package:mangayomi/modules/more/statistics/immersion_stats_screen.dart';
+import 'package:mangayomi/modules/more/statistics/immersion_stats_titles_screen.dart';
 import 'package:mangayomi/modules/more/statistics/statistics_screen.dart';
 import 'package:mangayomi/modules/novel/novel_reader_view.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_screen.dart';
@@ -223,6 +226,25 @@ class RouterNotifier extends ChangeNotifier {
       builder: (data) => CategoriesScreen(data: data),
     ),
     _genericRoute(name: "statistics", child: const StatisticsScreen()),
+    _genericRoute(
+      path: "/statistics/immersion",
+      name: "immersionStatistics",
+      child: const ImmersionStatsScreen(),
+    ),
+    _genericRoute<ImmersionStatsQuery>(
+      path: "/statistics/titles",
+      name: "immersionStatisticsTitles",
+      builder: (query) => ImmersionStatsTitlesScreen(query: query),
+    ),
+    _genericRoute<ImmersionStatsTitle>(
+      path: "/statistics/title",
+      name: "immersionStatisticsTitle",
+      builder: (title) => ImmersionStatsScreen(
+        titleId: title.id,
+        isNovel: title.isNovel,
+        titleName: title.title,
+      ),
+    ),
     _genericRoute(name: "general", child: const GeneralScreen()),
     _genericRoute(name: "readerMode", child: const ReaderScreen()),
     _genericRoute(name: "dictionary", child: const DictionaryScreen()),

--- a/lib/services/statistics/anki_stats_recorder.dart
+++ b/lib/services/statistics/anki_stats_recorder.dart
@@ -1,0 +1,59 @@
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/epub_book_progress.dart';
+import 'package:mangayomi/services/mining/dictionary_profile.dart';
+import 'package:mangayomi/services/mining/mining_models.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_storage.dart';
+import 'package:mangayomi/services/sync/chimahon_novel_progress_adapter.dart';
+
+/// Records a successfully mined Anki card into immersion statistics.
+///
+/// Chimahon buckets cards by media type and attributes them to the title being
+/// read, so the per-title statistics view can show how many cards came from
+/// each book. Manga rows use the library ID; novel rows use Chimahon's stable
+/// book ID.
+abstract final class AnkiStatsRecorder {
+  /// Called after a card is added or overwritten, matching Chimahon's call
+  /// sites. Failures are swallowed: losing a statistics row must never surface
+  /// as a mining error after the card has already been created.
+  static Future<void> recordCard({
+    required MiningContext context,
+    required DictionaryProfile profile,
+  }) async {
+    try {
+      await ImmersionStatsStorage.addAnkiCard(
+        type: _statsType(context.mediaType),
+        profileId: profile.id,
+        titleId: _titleId(context),
+      );
+    } catch (_) {
+      // Statistics are advisory; the card itself already exists.
+    }
+  }
+
+  /// Chimahon only distinguishes manga from everything else, which it counts as
+  /// novel cards. Anime and unknown sources therefore land in `novelCards`,
+  /// exactly as they do there.
+  static String? _statsType(MiningMediaType mediaType) =>
+      mediaType == MiningMediaType.manga ? 'manga' : null;
+
+  static String? _titleId(MiningContext context) {
+    final novelId = context.novelId;
+    if (novelId != null && novelId.isNotEmpty) return novelId;
+
+    final mangaId = context.mangaId;
+    if (mangaId == null) return null;
+    // A local EPUB read through the manga pipeline still belongs to its
+    // Chimahon book identity, so prefer that when one exists.
+    final progress = isar.epubBookProgress
+        .filter()
+        .mangaIdEqualTo(mangaId)
+        .findFirstSync();
+    if (progress != null) {
+      final stableId = const ChimahonNovelProgressAdapter()
+          .stableLocalIdOrNull(progress);
+      if (stableId != null) return stableId;
+    }
+    return mangaId.toString();
+  }
+}

--- a/lib/services/statistics/immersion_stats_models.dart
+++ b/lib/services/statistics/immersion_stats_models.dart
@@ -1,0 +1,303 @@
+/// Chimahon-compatible immersion statistics records.
+///
+/// Field names, units, and identity tuples are deliberately identical to
+/// Chimahon's `com.canopus.chimareader.data` models so the same rows survive a
+/// backup round trip in either direction:
+///
+/// * [MangaStatsEntry] keys on `(dateKey, mangaId)` and stores reading time in
+///   **milliseconds**.
+/// * [NovelStatsEntry] keys on `dateKey` within a single book and stores
+///   reading time in **seconds** as a double.
+/// * [AnkiStatsEntry] keys on `(dateKey, profileId, titleId)`.
+library;
+
+/// One day of manga reading for one title.
+///
+/// `mangaId == 0` is Chimahon's bucket for reading that has no library entry,
+/// so it is a valid key rather than a missing value.
+class MangaStatsEntry {
+  const MangaStatsEntry({
+    required this.dateKey,
+    this.charactersRead = 0,
+    this.readingTimeMs = 0,
+    this.mangaId = 0,
+  });
+
+  factory MangaStatsEntry.fromJson(Map<dynamic, dynamic> json) =>
+      MangaStatsEntry(
+        dateKey: json['dateKey']?.toString() ?? '',
+        charactersRead: _int(json['charactersRead']),
+        readingTimeMs: _int(json['readingTime']),
+        mangaId: _int(json['mangaId']),
+      );
+
+  final String dateKey;
+  final int charactersRead;
+
+  /// Chimahon stores manga reading time in milliseconds.
+  final int readingTimeMs;
+  final int mangaId;
+
+  MangaStatsEntry copyWith({
+    String? dateKey,
+    int? charactersRead,
+    int? readingTimeMs,
+    int? mangaId,
+  }) => MangaStatsEntry(
+    dateKey: dateKey ?? this.dateKey,
+    charactersRead: charactersRead ?? this.charactersRead,
+    readingTimeMs: readingTimeMs ?? this.readingTimeMs,
+    mangaId: mangaId ?? this.mangaId,
+  );
+
+  /// Chimahon's wire field name is `readingTime`; the unit lives in the docs.
+  Map<String, dynamic> toJson() => {
+    'dateKey': dateKey,
+    'charactersRead': charactersRead,
+    'readingTime': readingTimeMs,
+    'mangaId': mangaId,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is MangaStatsEntry &&
+      other.dateKey == dateKey &&
+      other.charactersRead == charactersRead &&
+      other.readingTimeMs == readingTimeMs &&
+      other.mangaId == mangaId;
+
+  @override
+  int get hashCode =>
+      Object.hash(dateKey, charactersRead, readingTimeMs, mangaId);
+}
+
+/// One day of Anki mining, scoped to a dictionary profile and optional title.
+class AnkiStatsEntry {
+  const AnkiStatsEntry({
+    required this.dateKey,
+    this.mangaCards = 0,
+    this.novelCards = 0,
+    this.profileId = '',
+    this.titleId,
+  });
+
+  factory AnkiStatsEntry.fromJson(Map<dynamic, dynamic> json) => AnkiStatsEntry(
+    dateKey: json['dateKey']?.toString() ?? '',
+    mangaCards: _int(json['mangaCards']),
+    novelCards: _int(json['novelCards']),
+    profileId: json['profileId']?.toString() ?? '',
+    titleId: json['titleId']?.toString(),
+  );
+
+  final String dateKey;
+  final int mangaCards;
+  final int novelCards;
+  final String profileId;
+
+  /// Manga rows carry the library ID as a string; novel rows carry Chimahon's
+  /// stable book ID. `null` means the card was mined outside any title.
+  final String? titleId;
+
+  int get totalCards => mangaCards + novelCards;
+
+  AnkiStatsEntry copyWith({
+    String? dateKey,
+    int? mangaCards,
+    int? novelCards,
+    String? profileId,
+    String? titleId,
+  }) => AnkiStatsEntry(
+    dateKey: dateKey ?? this.dateKey,
+    mangaCards: mangaCards ?? this.mangaCards,
+    novelCards: novelCards ?? this.novelCards,
+    profileId: profileId ?? this.profileId,
+    titleId: titleId ?? this.titleId,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'dateKey': dateKey,
+    'mangaCards': mangaCards,
+    'novelCards': novelCards,
+    'profileId': profileId,
+    if (titleId != null) 'titleId': titleId,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnkiStatsEntry &&
+      other.dateKey == dateKey &&
+      other.mangaCards == mangaCards &&
+      other.novelCards == novelCards &&
+      other.profileId == profileId &&
+      other.titleId == titleId;
+
+  @override
+  int get hashCode =>
+      Object.hash(dateKey, mangaCards, novelCards, profileId, titleId);
+}
+
+/// One day of novel reading for one book.
+///
+/// This mirrors Chimahon's `Statistics`, including the derived speed fields it
+/// persists rather than recomputes. `completedBook`/`completedData` are not
+/// modelled: Chimahon never writes them from the reader and its backup schema
+/// omits them, so round-tripping them is not possible in either direction.
+class NovelStatsEntry {
+  const NovelStatsEntry({
+    required this.dateKey,
+    this.charactersRead = 0,
+    this.readingTimeSeconds = 0,
+    this.minReadingSpeed = 0,
+    this.altMinReadingSpeed = 0,
+    this.lastReadingSpeed = 0,
+    this.maxReadingSpeed = 0,
+    this.lastStatisticModified = 0,
+  });
+
+  factory NovelStatsEntry.fromJson(Map<dynamic, dynamic> json) =>
+      NovelStatsEntry(
+        dateKey: json['dateKey']?.toString() ?? '',
+        charactersRead: _int(json['charactersRead']),
+        readingTimeSeconds: _double(json['readingTime']),
+        minReadingSpeed: _int(json['minReadingSpeed']),
+        altMinReadingSpeed: _int(json['altMinReadingSpeed']),
+        lastReadingSpeed: _int(json['lastReadingSpeed']),
+        maxReadingSpeed: _int(json['maxReadingSpeed']),
+        lastStatisticModified: _int(json['lastStatisticModified']),
+      );
+
+  final String dateKey;
+  final int charactersRead;
+
+  /// Chimahon stores novel reading time in fractional seconds.
+  final double readingTimeSeconds;
+  final int minReadingSpeed;
+  final int altMinReadingSpeed;
+  final int lastReadingSpeed;
+  final int maxReadingSpeed;
+  final int lastStatisticModified;
+
+  int get readingTimeMs => (readingTimeSeconds * 1000).round();
+
+  NovelStatsEntry copyWith({
+    String? dateKey,
+    int? charactersRead,
+    double? readingTimeSeconds,
+    int? minReadingSpeed,
+    int? altMinReadingSpeed,
+    int? lastReadingSpeed,
+    int? maxReadingSpeed,
+    int? lastStatisticModified,
+  }) => NovelStatsEntry(
+    dateKey: dateKey ?? this.dateKey,
+    charactersRead: charactersRead ?? this.charactersRead,
+    readingTimeSeconds: readingTimeSeconds ?? this.readingTimeSeconds,
+    minReadingSpeed: minReadingSpeed ?? this.minReadingSpeed,
+    altMinReadingSpeed: altMinReadingSpeed ?? this.altMinReadingSpeed,
+    lastReadingSpeed: lastReadingSpeed ?? this.lastReadingSpeed,
+    maxReadingSpeed: maxReadingSpeed ?? this.maxReadingSpeed,
+    lastStatisticModified: lastStatisticModified ?? this.lastStatisticModified,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'dateKey': dateKey,
+    'charactersRead': charactersRead,
+    'readingTime': readingTimeSeconds,
+    'minReadingSpeed': minReadingSpeed,
+    'altMinReadingSpeed': altMinReadingSpeed,
+    'lastReadingSpeed': lastReadingSpeed,
+    'maxReadingSpeed': maxReadingSpeed,
+    'lastStatisticModified': lastStatisticModified,
+  };
+
+  /// Applies Chimahon's per-tick update, including its clamping rules.
+  ///
+  /// A negative [characterDiff] (the reader moved backwards) reduces the
+  /// running count but never below zero, and `altMinReadingSpeed` only moves
+  /// when characters actually changed so idle ticks cannot drag it to zero.
+  NovelStatsEntry updated({
+    required double timeDiffSeconds,
+    required int characterDiff,
+    required int modifiedAtMs,
+  }) {
+    final nextTime = readingTimeSeconds + timeDiffSeconds;
+    final nextCharacters = (charactersRead + characterDiff).clamp(
+      0,
+      1 << 62,
+    );
+    final nextSpeed = nextTime > 0
+        ? (nextCharacters / nextTime * 3600).toInt()
+        : 0;
+    return copyWith(
+      readingTimeSeconds: nextTime,
+      charactersRead: nextCharacters,
+      lastReadingSpeed: nextSpeed,
+      maxReadingSpeed: maxReadingSpeed > nextSpeed
+          ? maxReadingSpeed
+          : nextSpeed,
+      minReadingSpeed: minReadingSpeed != 0
+          ? (minReadingSpeed < nextSpeed ? minReadingSpeed : nextSpeed)
+          : nextSpeed,
+      altMinReadingSpeed: characterDiff != 0
+          ? (altMinReadingSpeed != 0
+                ? (altMinReadingSpeed < nextSpeed
+                      ? altMinReadingSpeed
+                      : nextSpeed)
+                : nextSpeed)
+          : altMinReadingSpeed,
+      lastStatisticModified: modifiedAtMs,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is NovelStatsEntry &&
+      other.dateKey == dateKey &&
+      other.charactersRead == charactersRead &&
+      other.readingTimeSeconds == readingTimeSeconds &&
+      other.minReadingSpeed == minReadingSpeed &&
+      other.altMinReadingSpeed == altMinReadingSpeed &&
+      other.lastReadingSpeed == lastReadingSpeed &&
+      other.maxReadingSpeed == maxReadingSpeed &&
+      other.lastStatisticModified == lastStatisticModified;
+
+  @override
+  int get hashCode => Object.hash(
+    dateKey,
+    charactersRead,
+    readingTimeSeconds,
+    minReadingSpeed,
+    altMinReadingSpeed,
+    lastReadingSpeed,
+    maxReadingSpeed,
+    lastStatisticModified,
+  );
+}
+
+/// Formats a date the way Chimahon's `LocalDate.toString()` does.
+String statsDateKey(DateTime date) {
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  return '${date.year.toString().padLeft(4, '0')}-$month-$day';
+}
+
+/// Parses a Chimahon `dateKey`, returning `null` for anything malformed.
+DateTime? parseStatsDateKey(String dateKey) {
+  final parsed = DateTime.tryParse(dateKey);
+  if (parsed == null) return null;
+  return DateTime(parsed.year, parsed.month, parsed.day);
+}
+
+int _int(Object? value) {
+  if (value is int) return value;
+  if (value is double) return value.round();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
+}
+
+double _double(Object? value) {
+  if (value is double) return value;
+  if (value is int) return value.toDouble();
+  if (value is String) return double.tryParse(value) ?? 0;
+  return 0;
+}

--- a/lib/services/statistics/immersion_stats_storage.dart
+++ b/lib/services/statistics/immersion_stats_storage.dart
@@ -1,0 +1,380 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:hive/hive.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
+
+/// Persistence for Chimahon-compatible immersion statistics.
+///
+/// Chimahon keeps three separate stores — `manga_stats.json`, `anki_stats.json`,
+/// and a per-book `statistics.json` — so this keeps the same three logical
+/// collections. They live in one Hive box because Mangatan has no equivalent of
+/// Chimahon's per-book directory, and the book's stable Chimahon ID is a
+/// sufficient key.
+///
+/// Every mutation is serialized through [_lock] so concurrent readers (page
+/// turns, the stats screen, a sync export) cannot interleave a read-modify-write
+/// and drop a day's reading.
+class ImmersionStatsStorage {
+  ImmersionStatsStorage._();
+
+  static const boxName = 'immersion_statistics';
+  static const _mangaKey = 'manga_stats';
+  static const _ankiKey = 'anki_stats';
+  static const _novelKeyPrefix = 'novel_stats_';
+
+  /// Bumped whenever anything is written so UI can re-read without polling.
+  static final revision = _StatsRevisionNotifier();
+
+  static Future<void> _lock = Future<void>.value();
+
+  /// Serializes [action] against every other mutation.
+  static Future<T> _synchronized<T>(Future<T> Function() action) {
+    final completer = Completer<T>();
+    _lock = _lock.then((_) async {
+      try {
+        completer.complete(await action());
+      } catch (error, stack) {
+        completer.completeError(error, stack);
+      }
+    });
+    return completer.future;
+  }
+
+  static Future<Box<dynamic>?> _box() async {
+    try {
+      if (Hive.isBoxOpen(boxName)) return Hive.box<dynamic>(boxName);
+      return await Hive.openBox<dynamic>(boxName);
+    } catch (_) {
+      // A stats read must never take down a reader. Losing the box degrades to
+      // "no statistics" rather than an unhandled error mid page turn.
+      return null;
+    }
+  }
+
+  // ---------------------------------------------------------------- manga
+
+  static Future<List<MangaStatsEntry>> loadMangaStats() async {
+    final raw = (await _box())?.get(_mangaKey);
+    return _decodeList(raw, MangaStatsEntry.fromJson);
+  }
+
+  static Future<void> saveMangaStats(List<MangaStatsEntry> stats) =>
+      _synchronized(() => _writeMangaStats(stats));
+
+  static Future<void> _writeMangaStats(List<MangaStatsEntry> stats) async {
+    final box = await _box();
+    if (box == null) return;
+    await box.put(_mangaKey, _encodeList(stats));
+    revision.bump();
+  }
+
+  /// Adds one page's worth of reading to today's row for [mangaId].
+  ///
+  /// Chimahon drops calls with nothing to record, which also keeps the store
+  /// from growing a row per idle page turn.
+  static Future<void> addMangaStats({
+    required int characters,
+    required int timeMs,
+    int mangaId = 0,
+    DateTime? date,
+  }) async {
+    if (characters <= 0 && timeMs <= 0) return;
+    final dateKey = statsDateKey(date ?? DateTime.now());
+    await _synchronized(() async {
+      final stats = await loadMangaStats();
+      final index = stats.indexWhere(
+        (entry) => entry.dateKey == dateKey && entry.mangaId == mangaId,
+      );
+      if (index >= 0) {
+        final existing = stats[index];
+        stats[index] = existing.copyWith(
+          charactersRead: existing.charactersRead + characters,
+          readingTimeMs: existing.readingTimeMs + timeMs,
+        );
+      } else {
+        stats.add(
+          MangaStatsEntry(
+            dateKey: dateKey,
+            charactersRead: characters,
+            readingTimeMs: timeMs,
+            mangaId: mangaId,
+          ),
+        );
+      }
+      await _writeMangaStats(stats);
+    });
+  }
+
+  /// Merges restored rows using Chimahon's max-per-field rule.
+  ///
+  /// Daily rows from two devices cannot be summed without double counting a
+  /// day that both devices already synced, so the larger value wins per field.
+  static Future<void> mergeMangaStats(
+    Iterable<MangaStatsEntry> incoming,
+  ) async {
+    final remote = incoming.toList();
+    if (remote.isEmpty) return;
+    await _synchronized(() async {
+      final local = await loadMangaStats();
+      var changed = false;
+      for (final entry in remote) {
+        final index = local.indexWhere(
+          (existing) =>
+              existing.dateKey == entry.dateKey &&
+              existing.mangaId == entry.mangaId,
+        );
+        if (index < 0) {
+          local.add(entry);
+          changed = true;
+          continue;
+        }
+        final existing = local[index];
+        if (entry.charactersRead > existing.charactersRead ||
+            entry.readingTimeMs > existing.readingTimeMs) {
+          local[index] = existing.copyWith(
+            charactersRead: entry.charactersRead > existing.charactersRead
+                ? entry.charactersRead
+                : existing.charactersRead,
+            readingTimeMs: entry.readingTimeMs > existing.readingTimeMs
+                ? entry.readingTimeMs
+                : existing.readingTimeMs,
+          );
+          changed = true;
+        }
+      }
+      if (changed) await _writeMangaStats(local);
+    });
+  }
+
+  // ----------------------------------------------------------------- anki
+
+  static Future<List<AnkiStatsEntry>> loadAnkiStats() async {
+    final raw = (await _box())?.get(_ankiKey);
+    return _decodeList(raw, AnkiStatsEntry.fromJson);
+  }
+
+  static Future<void> saveAnkiStats(List<AnkiStatsEntry> stats) =>
+      _synchronized(() => _writeAnkiStats(stats));
+
+  static Future<void> _writeAnkiStats(List<AnkiStatsEntry> stats) async {
+    final box = await _box();
+    if (box == null) return;
+    await box.put(_ankiKey, _encodeList(stats));
+    revision.bump();
+  }
+
+  /// Records one mined card. Anything that is not `manga` counts as a novel
+  /// card, matching Chimahon's branch.
+  static Future<void> addAnkiCard({
+    String? type,
+    String profileId = '',
+    String? titleId,
+    DateTime? date,
+  }) async {
+    final dateKey = statsDateKey(date ?? DateTime.now());
+    final isManga = type == 'manga';
+    await _synchronized(() async {
+      final stats = await loadAnkiStats();
+      final index = stats.indexWhere(
+        (entry) =>
+            entry.dateKey == dateKey &&
+            entry.profileId == profileId &&
+            entry.titleId == titleId,
+      );
+      if (index >= 0) {
+        final existing = stats[index];
+        stats[index] = existing.copyWith(
+          mangaCards: existing.mangaCards + (isManga ? 1 : 0),
+          novelCards: existing.novelCards + (isManga ? 0 : 1),
+        );
+      } else {
+        stats.add(
+          AnkiStatsEntry(
+            dateKey: dateKey,
+            mangaCards: isManga ? 1 : 0,
+            novelCards: isManga ? 0 : 1,
+            profileId: profileId,
+            titleId: titleId,
+          ),
+        );
+      }
+      await _writeAnkiStats(stats);
+    });
+  }
+
+  static Future<void> mergeAnkiStats(Iterable<AnkiStatsEntry> incoming) async {
+    final remote = incoming.toList();
+    if (remote.isEmpty) return;
+    await _synchronized(() async {
+      final local = await loadAnkiStats();
+      var changed = false;
+      for (final entry in remote) {
+        final index = local.indexWhere(
+          (existing) =>
+              existing.dateKey == entry.dateKey &&
+              existing.profileId == entry.profileId &&
+              existing.titleId == entry.titleId,
+        );
+        if (index < 0) {
+          local.add(entry);
+          changed = true;
+          continue;
+        }
+        final existing = local[index];
+        if (entry.mangaCards > existing.mangaCards ||
+            entry.novelCards > existing.novelCards) {
+          local[index] = existing.copyWith(
+            mangaCards: entry.mangaCards > existing.mangaCards
+                ? entry.mangaCards
+                : existing.mangaCards,
+            novelCards: entry.novelCards > existing.novelCards
+                ? entry.novelCards
+                : existing.novelCards,
+          );
+          changed = true;
+        }
+      }
+      if (changed) await _writeAnkiStats(local);
+    });
+  }
+
+  // ---------------------------------------------------------------- novel
+
+  static String _novelKey(String novelId) => '$_novelKeyPrefix$novelId';
+
+  static Future<List<NovelStatsEntry>> loadNovelStats(String novelId) async {
+    if (novelId.isEmpty) return const [];
+    final raw = (await _box())?.get(_novelKey(novelId));
+    return _decodeList(raw, NovelStatsEntry.fromJson);
+  }
+
+  static Future<void> saveNovelStats(
+    String novelId,
+    List<NovelStatsEntry> stats,
+  ) => _synchronized(() => _writeNovelStats(novelId, stats));
+
+  static Future<void> _writeNovelStats(
+    String novelId,
+    List<NovelStatsEntry> stats,
+  ) async {
+    if (novelId.isEmpty) return;
+    final box = await _box();
+    if (box == null) return;
+    await box.put(_novelKey(novelId), _encodeList(stats));
+    revision.bump();
+  }
+
+  /// Returns every book that has stored statistics, keyed by Chimahon ID.
+  static Future<Map<String, List<NovelStatsEntry>>> loadAllNovelStats() async {
+    final box = await _box();
+    if (box == null) return const {};
+    final result = <String, List<NovelStatsEntry>>{};
+    for (final key in box.keys) {
+      final name = key.toString();
+      if (!name.startsWith(_novelKeyPrefix)) continue;
+      final novelId = name.substring(_novelKeyPrefix.length);
+      if (novelId.isEmpty) continue;
+      final stats = _decodeList(box.get(key), NovelStatsEntry.fromJson);
+      if (stats.isNotEmpty) result[novelId] = stats;
+    }
+    return result;
+  }
+
+  /// Merges one book's restored rows.
+  ///
+  /// Unlike the daily manga/Anki rows, Chimahon's novel statistics carry
+  /// `lastStatisticModified`, so the newer row wins outright and ties keep the
+  /// local copy.
+  static Future<void> mergeNovelStats(
+    String novelId,
+    Iterable<NovelStatsEntry> incoming,
+  ) async {
+    if (novelId.isEmpty) return;
+    final remote = incoming.toList();
+    if (remote.isEmpty) return;
+    await _synchronized(() async {
+      final local = await loadNovelStats(novelId);
+      var changed = false;
+      for (final entry in remote) {
+        final index = local.indexWhere(
+          (existing) => existing.dateKey == entry.dateKey,
+        );
+        if (index < 0) {
+          local.add(entry);
+          changed = true;
+          continue;
+        }
+        final existing = local[index];
+        if (entry.lastStatisticModified > existing.lastStatisticModified) {
+          local[index] = entry;
+          changed = true;
+        }
+      }
+      if (changed) await _writeNovelStats(novelId, local);
+    });
+  }
+
+  /// Drops a book's statistics when its library entry is removed.
+  static Future<void> deleteNovelStats(String novelId) async {
+    if (novelId.isEmpty) return;
+    await _synchronized(() async {
+      final box = await _box();
+      if (box == null) return;
+      await box.delete(_novelKey(novelId));
+      revision.bump();
+    });
+  }
+
+  /// Clears everything. Used by "reset statistics" and by tests.
+  static Future<void> clear() async {
+    await _synchronized(() async {
+      final box = await _box();
+      if (box == null) return;
+      await box.clear();
+      revision.bump();
+    });
+  }
+
+  static List<T> _decodeList<T>(
+    Object? raw,
+    T Function(Map<dynamic, dynamic>) fromJson,
+  ) {
+    if (raw is! String || raw.isEmpty) return <T>[];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return <T>[];
+      return [
+        for (final item in decoded)
+          if (item is Map) fromJson(item),
+      ];
+    } catch (_) {
+      // A corrupt payload is treated as empty rather than propagating: the
+      // next write repairs it, and reading is on the page-turn path.
+      return <T>[];
+    }
+  }
+
+  static String _encodeList(List<dynamic> stats) =>
+      jsonEncode([for (final entry in stats) entry.toJson()]);
+}
+
+/// A tiny listenable so widgets can rebuild after a write without importing
+/// Flutter into the storage layer's dependencies beyond `ChangeNotifier`.
+class _StatsRevisionNotifier {
+  int _value = 0;
+  final _listeners = <void Function()>[];
+
+  int get value => _value;
+
+  void addListener(void Function() listener) => _listeners.add(listener);
+
+  void removeListener(void Function() listener) => _listeners.remove(listener);
+
+  void bump() {
+    _value++;
+    for (final listener in List<void Function()>.of(_listeners)) {
+      listener();
+    }
+  }
+}

--- a/lib/services/statistics/manga_statistics_tracker.dart
+++ b/lib/services/statistics/manga_statistics_tracker.dart
@@ -1,0 +1,157 @@
+import 'package:mangayomi/services/statistics/immersion_stats_storage.dart';
+
+/// Live totals for the manga stats sheet.
+class MangaStatisticsSession {
+  const MangaStatisticsSession({
+    this.charactersRead = 0,
+    this.readingTimeMs = 0,
+    this.isTracking = true,
+  });
+
+  final int charactersRead;
+  final int readingTimeMs;
+  final bool isTracking;
+
+  int get charactersPerHour => readingTimeMs > 0
+      ? (charactersRead / (readingTimeMs / 3600000)).toInt()
+      : 0;
+
+  MangaStatisticsSession copyWith({
+    int? charactersRead,
+    int? readingTimeMs,
+    bool? isTracking,
+  }) => MangaStatisticsSession(
+    charactersRead: charactersRead ?? this.charactersRead,
+    readingTimeMs: readingTimeMs ?? this.readingTimeMs,
+    isTracking: isTracking ?? this.isTracking,
+  );
+}
+
+/// Port of Chimahon's manga-side page dwell tracking (`trackMangaStats`).
+///
+/// Unlike the novel reader, which knows an absolute character position, the
+/// manga reader learns a page's character count only after OCR has run. So each
+/// page is attributed when the reader *leaves* it: the dwell time is the gap
+/// between page changes and the characters are that page's OCR text length.
+class MangaStatisticsTracker {
+  MangaStatisticsTracker({
+    required this.mangaId,
+    this.enabled = true,
+    Stopwatch Function()? stopwatchFactory,
+  }) : _elapsed = (stopwatchFactory ?? Stopwatch.new)()..start();
+
+  /// Chimahon buckets reading with no library entry under id 0.
+  final int mangaId;
+  final bool enabled;
+
+  /// Chimahon caps a single page's attributed time. Anything longer is the app
+  /// having sat in the background or the device asleep, not reading.
+  static const maxPageDurationMs = 120000;
+
+  /// Below this, a page was flipped past rather than read.
+  static const minPageDurationMs = 500;
+
+  final Stopwatch _elapsed;
+
+  /// Pages already counted this chapter, so scrolling back and forth over the
+  /// same page cannot inflate the character total.
+  final Set<int> _consumedPages = <int>{};
+
+  int? _currentPageIndex;
+  int _lastTimestampMs = 0;
+  MangaStatisticsSession _session = const MangaStatisticsSession();
+
+  MangaStatisticsSession get session => _session;
+
+  bool get isTracking => _session.isTracking;
+
+  void toggleTracking() {
+    _session = _session.copyWith(isTracking: !_session.isTracking);
+    // Restart the window so paused time is never attributed to the next page.
+    _lastTimestampMs = _elapsed.elapsedMilliseconds;
+  }
+
+  /// Called when the visible page changes, and with `null` when the reader
+  /// closes or switches chapter.
+  ///
+  /// [charactersForPage] resolves the *previous* page's OCR character count. It
+  /// is a callback because OCR may still have been running while that page was
+  /// on screen.
+  Future<void> onPageChanged({
+    required int? pageIndex,
+    required Future<int> Function(int pageIndex) charactersForPage,
+    bool incognito = false,
+  }) async {
+    if (pageIndex == null) _consumedPages.clear();
+
+    final now = _elapsed.elapsedMilliseconds;
+    final previousPage = _currentPageIndex;
+    final rawTime = now - _lastTimestampMs;
+    final timeSpent = rawTime > maxPageDurationMs ? maxPageDurationMs : rawTime;
+
+    _currentPageIndex = pageIndex;
+    _lastTimestampMs = now;
+
+    if (!enabled ||
+        incognito ||
+        previousPage == null ||
+        timeSpent <= minPageDurationMs ||
+        _consumedPages.contains(previousPage)) {
+      return;
+    }
+    _consumedPages.add(previousPage);
+
+    final characters = await charactersForPage(previousPage);
+    await ImmersionStatsStorage.addMangaStats(
+      characters: characters,
+      timeMs: timeSpent,
+      mangaId: mangaId,
+    );
+    if (_session.isTracking) {
+      _session = _session.copyWith(
+        charactersRead: _session.charactersRead + characters,
+        readingTimeMs: _session.readingTimeMs + timeSpent,
+      );
+    }
+  }
+
+  /// Attributes the page currently on screen, for reader teardown.
+  Future<void> flush({
+    required Future<int> Function(int pageIndex) charactersForPage,
+    bool incognito = false,
+  }) => onPageChanged(
+    pageIndex: null,
+    charactersForPage: charactersForPage,
+    incognito: incognito,
+  );
+
+  /// Forgets consumed pages when moving to a new chapter, matching Chimahon's
+  /// per-chapter dedup scope.
+  void resetChapter() {
+    _consumedPages.clear();
+    _lastTimestampMs = _elapsed.elapsedMilliseconds;
+  }
+}
+
+/// Remaining-time projections shown in the manga stats sheet.
+class MangaStatsEstimate {
+  const MangaStatsEstimate({
+    this.remainingBookCharacters = 0,
+    this.remainingChapterCharacters = 0,
+    this.remainingBookSeconds = 0,
+    this.remainingChapterSeconds = 0,
+  });
+
+  final int remainingBookCharacters;
+  final int remainingChapterCharacters;
+  final double remainingBookSeconds;
+  final double remainingChapterSeconds;
+
+  /// Converts a remaining character count into seconds at [charactersPerHour].
+  /// A zero or unknown speed yields zero rather than infinity.
+  static double secondsRemaining(int remainingCharacters, int charactersPerHour) {
+    if (charactersPerHour <= 0) return 0;
+    final remaining = remainingCharacters < 0 ? 0 : remainingCharacters;
+    return remaining / (charactersPerHour / 3600);
+  }
+}

--- a/lib/services/statistics/novel_statistics_tracker.dart
+++ b/lib/services/statistics/novel_statistics_tracker.dart
@@ -1,0 +1,213 @@
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_storage.dart';
+
+/// Session/today/all-time view of one novel's reading, refreshed on every tick.
+class NovelStatisticsState {
+  const NovelStatisticsState({
+    required this.isTracking,
+    required this.session,
+    required this.today,
+    required this.allTime,
+  });
+
+  final bool isTracking;
+  final NovelStatsEntry session;
+  final NovelStatsEntry today;
+  final NovelStatsEntry allTime;
+
+  NovelStatisticsState copyWith({
+    bool? isTracking,
+    NovelStatsEntry? session,
+    NovelStatsEntry? today,
+    NovelStatsEntry? allTime,
+  }) => NovelStatisticsState(
+    isTracking: isTracking ?? this.isTracking,
+    session: session ?? this.session,
+    today: today ?? this.today,
+    allTime: allTime ?? this.allTime,
+  );
+}
+
+/// Port of Chimahon's `ReaderStatisticsTracker`.
+///
+/// The reader reports its absolute explored character position; this converts
+/// successive positions plus wall-clock deltas into per-day statistics. All the
+/// clamping quirks are Chimahon's and are preserved so the same reading
+/// produces the same numbers in both apps.
+class NovelStatisticsTracker {
+  NovelStatisticsTracker({
+    required this.novelId,
+    List<NovelStatsEntry> initialStatistics = const [],
+    this.enabled = true,
+    DateTime Function()? clock,
+  }) : _clock = clock ?? DateTime.now,
+       _statistics = List.of(initialStatistics) {
+    _lastTimestampMs = _nowMs();
+    _state = NovelStatisticsState(
+      isTracking: false,
+      session: _defaultEntry(),
+      today: _entryForDate(_currentDateKey()),
+      allTime: _allTimeEntry(_statistics),
+    );
+  }
+
+  /// Chimahon's stable book identity. An empty ID disables persistence.
+  final String novelId;
+  final bool enabled;
+  final DateTime Function() _clock;
+
+  List<NovelStatsEntry> _statistics;
+  late NovelStatisticsState _state;
+  late int _lastTimestampMs;
+  int _lastCharacterCount = 0;
+  bool _hasUpdated = false;
+
+  NovelStatisticsState get state => _state;
+
+  /// Position the ETA projections should use while tracking is paused, so page
+  /// flips during a pause do not move the estimate.
+  int get frozenPosition => _lastCharacterCount;
+
+  bool get hasUnsavedUpdates => _hasUpdated;
+
+  void start(int currentCharacter) {
+    if (!enabled) return;
+    _state = _state.copyWith(isTracking: true);
+    resetBaseline(currentCharacter);
+  }
+
+  void startForPageTurnIfNeeded(int currentCharacter) {
+    if (!_state.isTracking) start(currentCharacter);
+  }
+
+  void stop(int currentCharacter) => pause(currentCharacter);
+
+  bool pause(int currentCharacter) {
+    if (!_state.isTracking) return false;
+    update(currentCharacter);
+    _state = _state.copyWith(isTracking: false);
+    return true;
+  }
+
+  void togglePause(int currentCharacter) {
+    if (_state.isTracking) {
+      pause(currentCharacter);
+    } else {
+      start(currentCharacter);
+    }
+  }
+
+  /// Folds the time and characters since the last call into all three buckets.
+  void update(int currentCharacter) {
+    if (!enabled || !_state.isTracking) return;
+    _rollTodayIfNeeded();
+    final now = _nowMs();
+    final timeDiff = (now - _lastTimestampMs) / 1000.0;
+    if (timeDiff <= 0) return;
+
+    final charDiff = currentCharacter - _lastCharacterCount;
+    // A large jump backwards (chapter restart, TOC jump) must not push the
+    // session negative; it can only cancel what this session counted.
+    final finalCharDiff =
+        charDiff < 0 && charDiff.abs() > _state.session.charactersRead
+        ? -_state.session.charactersRead
+        : charDiff;
+    final modified = now;
+    _state = _state.copyWith(
+      session: _state.session.updated(
+        timeDiffSeconds: timeDiff,
+        characterDiff: finalCharDiff,
+        modifiedAtMs: modified,
+      ),
+      today: _state.today.updated(
+        timeDiffSeconds: timeDiff,
+        characterDiff: finalCharDiff,
+        modifiedAtMs: modified,
+      ),
+      allTime: _state.allTime.updated(
+        timeDiffSeconds: timeDiff,
+        characterDiff: finalCharDiff,
+        modifiedAtMs: modified,
+      ),
+    );
+    _hasUpdated = true;
+    _lastTimestampMs = now;
+    _lastCharacterCount = currentCharacter;
+  }
+
+  /// Re-anchors position and time without recording anything, for jumps that
+  /// are navigation rather than reading.
+  void resetBaseline(int currentCharacter) {
+    _lastCharacterCount = currentCharacter;
+    _lastTimestampMs = _nowMs();
+  }
+
+  /// The rows to persist: stored days, deduplicated by most recently modified,
+  /// with today's live row replacing its stored counterpart.
+  List<NovelStatsEntry> statisticsForPersistence() {
+    final today = _state.today;
+    final grouped = <String, NovelStatsEntry>{};
+    for (final entry in _statistics) {
+      final existing = grouped[entry.dateKey];
+      if (existing == null ||
+          entry.lastStatisticModified >= existing.lastStatisticModified) {
+        grouped[entry.dateKey] = entry;
+      }
+    }
+    grouped[today.dateKey] = today;
+    final next = grouped.values.toList();
+    _statistics = List.of(next);
+    return next;
+  }
+
+  List<NovelStatsEntry>? statisticsForPersistenceOrNull() =>
+      enabled && (_hasUpdated || _statistics.isNotEmpty)
+      ? statisticsForPersistence()
+      : null;
+
+  /// Writes the current statistics for this book, if there is anything to save.
+  Future<void> persist() async {
+    final stats = statisticsForPersistenceOrNull();
+    if (stats == null || novelId.isEmpty) return;
+    await ImmersionStatsStorage.saveNovelStats(novelId, stats);
+    _hasUpdated = false;
+  }
+
+  /// Rolls over at midnight so a session spanning two days is split correctly.
+  void _rollTodayIfNeeded() {
+    final key = _currentDateKey();
+    if (_state.today.dateKey == key) return;
+    statisticsForPersistence();
+    _state = _state.copyWith(today: _entryForDate(key));
+  }
+
+  NovelStatsEntry _entryForDate(String dateKey) {
+    for (final entry in _statistics) {
+      if (entry.dateKey == dateKey) return entry;
+    }
+    return _defaultEntry(dateKey);
+  }
+
+  NovelStatsEntry _defaultEntry([String? dateKey]) =>
+      NovelStatsEntry(dateKey: dateKey ?? _currentDateKey());
+
+  NovelStatsEntry _allTimeEntry(List<NovelStatsEntry> statistics) {
+    var total = _defaultEntry();
+    for (final entry in statistics) {
+      final readingTime = total.readingTimeSeconds + entry.readingTimeSeconds;
+      final charactersRead = total.charactersRead + entry.charactersRead;
+      total = total.copyWith(
+        readingTimeSeconds: readingTime,
+        charactersRead: charactersRead,
+        lastReadingSpeed: readingTime > 0
+            ? (charactersRead / readingTime * 3600).toInt()
+            : 0,
+      );
+    }
+    return total;
+  }
+
+  int _nowMs() => _clock().millisecondsSinceEpoch;
+
+  String _currentDateKey() => statsDateKey(_clock());
+}

--- a/lib/services/sync/chimahon_generic_collection_safety_audit.dart
+++ b/lib/services/sync/chimahon_generic_collection_safety_audit.dart
@@ -5,6 +5,7 @@ import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupFe
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupMihon.pb.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupSavedSearch.pb.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupSource.pb.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupStatistics.pb.dart';
 import 'package:mangayomi/services/sync/chimahon_feed_identity.dart';
 import 'package:mangayomi/services/sync/chimahon_opaque_rows.dart';
 import 'package:mangayomi/services/sync/chimahon_unknown_field_safety.dart';
@@ -14,9 +15,9 @@ import 'package:protobuf/protobuf.dart';
 ///
 /// Local known fields win ordinary conflicts for these keyed collections, but
 /// remote identities and both sides' future protobuf fields must survive. The
-/// global statistics collections are intentionally treated as exact opaque
-/// rows: Chimahon excludes them from normal sync and manga statistics contain
-/// a device-local database ID, so Mangatan must not invent a cross-device key.
+/// global statistics collections are checked on Chimahon's own daily identity
+/// and for counter regressions rather than byte equality, because the merger
+/// intentionally rewrites those rows to the larger value per field.
 class ChimahonGenericCollectionSafetyAudit {
   const ChimahonGenericCollectionSafetyAudit();
 
@@ -82,7 +83,7 @@ class ChimahonGenericCollectionSafetyAudit {
       proposed: proposed,
       fail: fail,
     );
-    _auditOpaqueStatistics(
+    _auditStatistics(
       local: local,
       remote: remote,
       proposed: proposed,
@@ -274,50 +275,91 @@ class ChimahonGenericCollectionSafetyAudit {
     fail('local_root_unknown_field_changed_in_proposed', localChanged);
   }
 
-  void _auditOpaqueStatistics({
+  /// Verifies that merging statistics neither drops a day nor loses reading.
+  ///
+  /// These rows are now produced locally rather than passed through opaquely,
+  /// so exact-byte preservation is no longer the right check: the merger
+  /// deliberately rewrites a row to the larger value per field. What must still
+  /// hold is that every `(dateKey, id)` present on either side survives, and
+  /// that no counter goes backwards — a regression would silently erase
+  /// recorded reading or mined cards.
+  void _auditStatistics({
     required BackupMihon local,
     required BackupMihon remote,
     required BackupMihon proposed,
     required void Function(String code, Iterable<String> affected) fail,
     required void Function(String code, Iterable<String> affected) observe,
   }) {
-    fail(
-      'local_manga_stat_missing_from_proposed',
-      ChimahonOpaqueRows.missingExactRows(
-        local.backupMangaStats,
-        proposed.backupMangaStats,
-      ),
+    final proposedManga = _statsByKey(
+      proposed.backupMangaStats,
+      _mangaStatKey,
     );
-    fail(
-      'remote_manga_stat_missing_from_proposed',
-      ChimahonOpaqueRows.missingExactRows(
-        remote.backupMangaStats,
-        proposed.backupMangaStats,
-      ),
-    );
-    fail(
-      'local_anki_stat_missing_from_proposed',
-      ChimahonOpaqueRows.missingExactRows(
-        local.backupAnkiStats,
-        proposed.backupAnkiStats,
-      ),
-    );
-    fail(
-      'remote_anki_stat_missing_from_proposed',
-      ChimahonOpaqueRows.missingExactRows(
-        remote.backupAnkiStats,
-        proposed.backupAnkiStats,
-      ),
-    );
+    final proposedAnki = _statsByKey(proposed.backupAnkiStats, _ankiStatKey);
+
+    for (final side in [('local', local), ('remote', remote)]) {
+      final missingManga = <String>[];
+      final regressedManga = <String>[];
+      for (final row in side.$2.backupMangaStats) {
+        final key = _mangaStatKey(row);
+        final candidate = proposedManga[key];
+        if (candidate == null) {
+          missingManga.add(key);
+        } else if (candidate.charactersRead < row.charactersRead ||
+            candidate.readingTime < row.readingTime) {
+          regressedManga.add(key);
+        }
+      }
+      fail('${side.$1}_manga_stat_missing_from_proposed', missingManga);
+      fail('${side.$1}_manga_stat_regressed_in_proposed', regressedManga);
+
+      final missingAnki = <String>[];
+      final regressedAnki = <String>[];
+      for (final row in side.$2.backupAnkiStats) {
+        final key = _ankiStatKey(row);
+        final candidate = proposedAnki[key];
+        if (candidate == null) {
+          missingAnki.add(key);
+        } else if (candidate.mangaCards < row.mangaCards ||
+            candidate.novelCards < row.novelCards) {
+          regressedAnki.add(key);
+        }
+      }
+      fail('${side.$1}_anki_stat_missing_from_proposed', missingAnki);
+      fail('${side.$1}_anki_stat_regressed_in_proposed', regressedAnki);
+    }
+
     observe(
-      'manga_statistics_manual_backup_only',
+      'manga_statistics_merged',
       ChimahonOpaqueRows.opaqueDigests(proposed.backupMangaStats),
     );
     observe(
-      'anki_statistics_manual_backup_only',
+      'anki_statistics_merged',
       ChimahonOpaqueRows.opaqueDigests(proposed.backupAnkiStats),
     );
   }
+
+  /// Keeps the row with the largest counters per key, so an audit against a
+  /// side that itself contains duplicate keys still compares against the
+  /// strongest claim rather than whichever row happened to come last.
+  Map<String, T> _statsByKey<T extends GeneratedMessage>(
+    Iterable<T> rows,
+    String Function(T row) keyOf,
+  ) {
+    final result = <String, T>{};
+    for (final row in rows) {
+      result[keyOf(row)] = row;
+    }
+    return result;
+  }
+
+  static String _mangaStatKey(BackupMangaStats row) =>
+      '${row.dateKey}|${row.mangaId}';
+
+  /// An absent `titleId` is distinct from an empty one, so the sentinel must
+  /// not collide with a real empty-string title ID.
+  static String _ankiStatKey(BackupAnkiStats row) =>
+      '${row.dateKey}|${row.profileId}|'
+      '${row.hasTitleId() ? 'id:${row.titleId}' : 'none'}';
 
   T _messageWithOnlyUnknownField<T extends GeneratedMessage>(
     T source,

--- a/lib/services/sync/chimahon_local_sync_projection_service.dart
+++ b/lib/services/sync/chimahon_local_sync_projection_service.dart
@@ -19,6 +19,7 @@ import 'package:mangayomi/services/sync/chimahon_novel_materializer.dart';
 import 'package:mangayomi/services/sync/chimahon_source_preferences_adapter.dart';
 import 'package:mangayomi/services/sync/chimahon_sync_merger.dart';
 import 'package:mangayomi/services/sync/chimahon_tracking_adapter.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_storage.dart';
 import 'package:mangayomi/services/sync/mihon_backup_exporter.dart';
 
 typedef ChimahonMediaSyncSelectionProvider =
@@ -243,6 +244,9 @@ class ChimahonLocalSyncProjectionService {
       deletedTracks: trackingDeletions.deletions,
       appPreferences: appPreferences,
       sourcePreferences: sourcePreferences,
+      mangaStats: await ImmersionStatsStorage.loadMangaStats(),
+      ankiStats: await ImmersionStatsStorage.loadAnkiStats(),
+      novelStats: await ImmersionStatsStorage.loadAllNovelStats(),
     );
     // Keep every local media record until the engine has read the current
     // remote and can safely resolve a first-contact selection. Only the exact

--- a/lib/services/sync/chimahon_pending_restore_authority.dart
+++ b/lib/services/sync/chimahon_pending_restore_authority.dart
@@ -10,8 +10,9 @@ import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupHi
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupManga.pb.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupMihon.pb.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupNovel.pb.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupStatistics.pb.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupTracking.pb.dart';
-import 'package:mangayomi/services/sync/chimahon_opaque_rows.dart';
+import 'package:mangayomi/services/sync/chimahon_stats_row_merge.dart';
 import 'package:mangayomi/services/sync/chimahon_sync_merger.dart';
 import 'package:protobuf/protobuf.dart';
 
@@ -156,7 +157,7 @@ class ChimahonPendingRestoreAuthority {
     result.backupMangaStats
       ..clear()
       ..addAll(
-        ChimahonOpaqueRows.mergeMaxMultiplicity(
+        ChimahonStatsRowMerge.mangaStats(
           merged.backupMangaStats,
           pending.backupMangaStats,
         ),
@@ -164,7 +165,7 @@ class ChimahonPendingRestoreAuthority {
     result.backupAnkiStats
       ..clear()
       ..addAll(
-        ChimahonOpaqueRows.mergeMaxMultiplicity(
+        ChimahonStatsRowMerge.ankiStats(
           merged.backupAnkiStats,
           pending.backupAnkiStats,
         ),
@@ -265,20 +266,50 @@ class ChimahonPendingRestoreAuthority {
     )) {
       return false;
     }
-    if (ChimahonOpaqueRows.missingExactRows(
-      pending.backupMangaStats,
-      uploaded.backupMangaStats,
-    ).isNotEmpty) {
+    // Statistics are merged rather than passed through, so the upload cannot be
+    // expected to contain the pending rows byte for byte. What must hold is that
+    // every pending day survives and no counter went backwards.
+    if (!_statisticsRepresented<BackupMangaStats>(
+      pending: pending.backupMangaStats,
+      uploaded: uploaded.backupMangaStats,
+      keyOf: ChimahonStatsRowMerge.mangaKey,
+      covers: (uploadedRow, pendingRow) =>
+          uploadedRow.charactersRead >= pendingRow.charactersRead &&
+          uploadedRow.readingTime >= pendingRow.readingTime,
+    )) {
       return false;
     }
-    if (ChimahonOpaqueRows.missingExactRows(
-      pending.backupAnkiStats,
-      uploaded.backupAnkiStats,
-    ).isNotEmpty) {
+    if (!_statisticsRepresented<BackupAnkiStats>(
+      pending: pending.backupAnkiStats,
+      uploaded: uploaded.backupAnkiStats,
+      keyOf: ChimahonStatsRowMerge.ankiKey,
+      covers: (uploadedRow, pendingRow) =>
+          uploadedRow.mangaCards >= pendingRow.mangaCards &&
+          uploadedRow.novelCards >= pendingRow.novelCards,
+    )) {
       return false;
     }
 
     return _containsPendingPreferences(uploaded, pending, localIntent);
+  }
+
+  /// True when every pending statistics row has an uploaded counterpart on the
+  /// same daily identity whose counters are at least as large.
+  bool _statisticsRepresented<T extends GeneratedMessage>({
+    required Iterable<T> pending,
+    required Iterable<T> uploaded,
+    required String Function(T row) keyOf,
+    required bool Function(T uploadedRow, T pendingRow) covers,
+  }) {
+    final uploadedByKey = <String, T>{};
+    for (final row in uploaded) {
+      uploadedByKey[keyOf(row)] = row;
+    }
+    for (final row in pending) {
+      final candidate = uploadedByKey[keyOf(row)];
+      if (candidate == null || !covers(candidate, row)) return false;
+    }
+    return true;
   }
 
   BackupManga _overlayManga(

--- a/lib/services/sync/chimahon_stats_adapter.dart
+++ b/lib/services/sync/chimahon_stats_adapter.dart
@@ -1,0 +1,117 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupNovel.pb.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupStatistics.pb.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
+
+/// Lossless mapping between immersion statistics and Chimahon's backup rows.
+///
+/// The three collections travel differently in Chimahon's envelope: manga and
+/// Anki statistics are top-level repeated fields (710 and 711), while a novel's
+/// statistics are nested inside its own `BackupNovel`. That shape is preserved
+/// so a Mangatan backup restores in Chimahon and vice versa.
+class ChimahonStatsAdapter {
+  const ChimahonStatsAdapter();
+
+  // ---------------------------------------------------------------- manga
+
+  BackupMangaStats exportMangaStats(MangaStatsEntry entry) => BackupMangaStats(
+    dateKey: entry.dateKey,
+    charactersRead: entry.charactersRead,
+    readingTime: Int64(entry.readingTimeMs),
+    mangaId: Int64(entry.mangaId),
+  );
+
+  List<BackupMangaStats> exportAllMangaStats(
+    Iterable<MangaStatsEntry> entries,
+  ) => [
+    for (final entry in entries)
+      // A row without a date key cannot be attributed to a day, so it would be
+      // unmergeable on the other side.
+      if (entry.dateKey.isNotEmpty) exportMangaStats(entry),
+  ];
+
+  MangaStatsEntry importMangaStats(BackupMangaStats stats) => MangaStatsEntry(
+    dateKey: stats.dateKey,
+    charactersRead: stats.charactersRead,
+    readingTimeMs: stats.readingTime.toInt(),
+    mangaId: stats.mangaId.toInt(),
+  );
+
+  List<MangaStatsEntry> importAllMangaStats(
+    Iterable<BackupMangaStats> stats,
+  ) => [
+    for (final entry in stats)
+      if (entry.dateKey.isNotEmpty) importMangaStats(entry),
+  ];
+
+  // ----------------------------------------------------------------- anki
+
+  BackupAnkiStats exportAnkiStats(AnkiStatsEntry entry) {
+    final stats = BackupAnkiStats(
+      dateKey: entry.dateKey,
+      mangaCards: entry.mangaCards,
+      novelCards: entry.novelCards,
+      profileId: entry.profileId,
+    );
+    // `titleId` is an optional proto field: leaving it absent is what marks a
+    // card mined outside any title, and is distinct from an empty string.
+    if (entry.titleId != null) stats.titleId = entry.titleId!;
+    return stats;
+  }
+
+  List<BackupAnkiStats> exportAllAnkiStats(Iterable<AnkiStatsEntry> entries) => [
+    for (final entry in entries)
+      if (entry.dateKey.isNotEmpty) exportAnkiStats(entry),
+  ];
+
+  AnkiStatsEntry importAnkiStats(BackupAnkiStats stats) => AnkiStatsEntry(
+    dateKey: stats.dateKey,
+    mangaCards: stats.mangaCards,
+    novelCards: stats.novelCards,
+    profileId: stats.profileId,
+    titleId: stats.hasTitleId() ? stats.titleId : null,
+  );
+
+  List<AnkiStatsEntry> importAllAnkiStats(Iterable<BackupAnkiStats> stats) => [
+    for (final entry in stats)
+      if (entry.dateKey.isNotEmpty) importAnkiStats(entry),
+  ];
+
+  // ---------------------------------------------------------------- novel
+
+  BackupNovelStat exportNovelStats(NovelStatsEntry entry) => BackupNovelStat(
+    dateKey: entry.dateKey,
+    charactersRead: entry.charactersRead,
+    readingTime: entry.readingTimeSeconds,
+    minReadingSpeed: entry.minReadingSpeed,
+    altMinReadingSpeed: entry.altMinReadingSpeed,
+    lastReadingSpeed: entry.lastReadingSpeed,
+    maxReadingSpeed: entry.maxReadingSpeed,
+    lastStatisticModified: Int64(entry.lastStatisticModified),
+  );
+
+  List<BackupNovelStat> exportAllNovelStats(
+    Iterable<NovelStatsEntry> entries,
+  ) => [
+    for (final entry in entries)
+      if (entry.dateKey.isNotEmpty) exportNovelStats(entry),
+  ];
+
+  NovelStatsEntry importNovelStats(BackupNovelStat stats) => NovelStatsEntry(
+    dateKey: stats.dateKey,
+    charactersRead: stats.charactersRead,
+    readingTimeSeconds: stats.readingTime,
+    minReadingSpeed: stats.minReadingSpeed,
+    altMinReadingSpeed: stats.altMinReadingSpeed,
+    lastReadingSpeed: stats.lastReadingSpeed,
+    maxReadingSpeed: stats.maxReadingSpeed,
+    lastStatisticModified: stats.lastStatisticModified.toInt(),
+  );
+
+  List<NovelStatsEntry> importAllNovelStats(
+    Iterable<BackupNovelStat> stats,
+  ) => [
+    for (final entry in stats)
+      if (entry.dateKey.isNotEmpty) importNovelStats(entry),
+  ];
+}

--- a/lib/services/sync/chimahon_stats_row_merge.dart
+++ b/lib/services/sync/chimahon_stats_row_merge.dart
@@ -1,0 +1,74 @@
+import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupStatistics.pb.dart';
+import 'package:protobuf/protobuf.dart';
+
+/// Chimahon's merge rule for the two global daily statistics collections.
+///
+/// These rows carry no modification clock, so neither side can be declared
+/// newer, and summing them would double count a day both devices already
+/// synced. Chimahon's `MangaStatsStorage.merge` / `AnkiStatsStorage.merge` take
+/// the larger value per field instead, which is idempotent and never loses
+/// recorded reading. Both sides' unknown fields are retained so a newer fork's
+/// additions survive.
+abstract final class ChimahonStatsRowMerge {
+  static List<BackupMangaStats> mangaStats(
+    Iterable<BackupMangaStats> local,
+    Iterable<BackupMangaStats> remote,
+  ) => _merge<BackupMangaStats>(
+    local,
+    remote,
+    keyOf: mangaKey,
+    combine: (winner, loser) => winner
+      ..charactersRead = _max(winner.charactersRead, loser.charactersRead)
+      ..readingTime = winner.readingTime > loser.readingTime
+          ? winner.readingTime
+          : loser.readingTime,
+  );
+
+  static List<BackupAnkiStats> ankiStats(
+    Iterable<BackupAnkiStats> local,
+    Iterable<BackupAnkiStats> remote,
+  ) => _merge<BackupAnkiStats>(
+    local,
+    remote,
+    keyOf: ankiKey,
+    combine: (winner, loser) => winner
+      ..mangaCards = _max(winner.mangaCards, loser.mangaCards)
+      ..novelCards = _max(winner.novelCards, loser.novelCards),
+  );
+
+  /// Chimahon keys a manga statistics row on the day and the title.
+  static String mangaKey(BackupMangaStats row) =>
+      '${row.dateKey}|${row.mangaId}';
+
+  /// Chimahon keys an Anki statistics row on the day, profile, and title. An
+  /// absent `titleId` means "mined outside any title" and must not collide with
+  /// a real, empty-string title ID.
+  static String ankiKey(BackupAnkiStats row) =>
+      '${row.dateKey}|${row.profileId}|'
+      '${row.hasTitleId() ? 'id:${row.titleId}' : 'none'}';
+
+  static List<T> _merge<T extends GeneratedMessage>(
+    Iterable<T> local,
+    Iterable<T> remote, {
+    required String Function(T row) keyOf,
+    required T Function(T winner, T loser) combine,
+  }) {
+    final byKey = <String, T>{};
+    final order = <String>[];
+    for (final row in [...local, ...remote]) {
+      final key = keyOf(row);
+      final existing = byKey[key];
+      if (existing == null) {
+        byKey[key] = row.deepCopy();
+        order.add(key);
+        continue;
+      }
+      final winner = existing.deepCopy();
+      winner.mergeUnknownFields(row.unknownFields);
+      byKey[key] = combine(winner, row);
+    }
+    return [for (final key in order) byKey[key]!];
+  }
+
+  static int _max(int a, int b) => a > b ? a : b;
+}

--- a/lib/services/sync/chimahon_sync_merger.dart
+++ b/lib/services/sync/chimahon_sync_merger.dart
@@ -20,7 +20,7 @@ import 'package:mangayomi/services/sync/chimahon_category_payload_adapter.dart';
 import 'package:mangayomi/services/sync/chimahon_feed_identity.dart';
 import 'package:mangayomi/services/sync/chimahon_media_child_projection_proof.dart';
 import 'package:mangayomi/services/sync/chimahon_media_parent_projection_proof.dart';
-import 'package:mangayomi/services/sync/chimahon_opaque_rows.dart';
+import 'package:mangayomi/services/sync/chimahon_stats_row_merge.dart';
 import 'package:protobuf/protobuf.dart';
 
 typedef ChimahonTrackingDeletionKey = ({int source, String url, int syncId});
@@ -139,11 +139,11 @@ class ChimahonSyncMerger {
         leftWinsTie,
       ),
       backupNovelCategories: novelCategories,
-      backupMangaStats: ChimahonOpaqueRows.mergeMaxMultiplicity(
+      backupMangaStats: ChimahonStatsRowMerge.mangaStats(
         local.backupMangaStats,
         remote.backupMangaStats,
       ),
-      backupAnkiStats: ChimahonOpaqueRows.mergeMaxMultiplicity(
+      backupAnkiStats: ChimahonStatsRowMerge.ankiStats(
         local.backupAnkiStats,
         remote.backupAnkiStats,
       ),

--- a/lib/services/sync/mihon_backup_exporter.dart
+++ b/lib/services/sync/mihon_backup_exporter.dart
@@ -14,13 +14,16 @@ import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupEp
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupHistory.pb.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupManga.pb.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupMihon.pb.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupNovel.pb.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupPreference.pb.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupSource.pb.dart';
 import 'package:mangayomi/services/sync/chimahon_manga_title_adapter.dart';
 import 'package:mangayomi/services/sync/chimahon_local_chapter_policy.dart';
 import 'package:mangayomi/services/sync/chimahon_novel_category_adapter.dart';
 import 'package:mangayomi/services/sync/chimahon_novel_progress_adapter.dart';
+import 'package:mangayomi/services/sync/chimahon_stats_adapter.dart';
 import 'package:mangayomi/services/sync/chimahon_tracking_adapter.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
 
 /// Pure mapper from Mangatan's persisted entities to the common Mihon backup
 /// envelope. Database access and scheduling deliberately remain outside it.
@@ -38,6 +41,9 @@ class MihonBackupExporter {
     Iterable<ChimahonTrackingDeletion> deletedTracks = const [],
     Iterable<BackupPreference> appPreferences = const [],
     Iterable<BackupSourcePreferences> sourcePreferences = const [],
+    Iterable<MangaStatsEntry> mangaStats = const [],
+    Iterable<AnkiStatsEntry> ankiStats = const [],
+    Map<String, List<NovelStatsEntry>> novelStats = const {},
   }) {
     final localMangas = mangas.toList(growable: false);
     final localCategories = categories.toList(growable: false);
@@ -280,12 +286,44 @@ class MihonBackupExporter {
       backupAnimeSources: usedAnimeSources.values,
       backupPreferences: appPreferences,
       backupSourcePreferences: sourcePreferences,
-      backupNovels: const ChimahonNovelProgressAdapter().exportAll(
-        epubBookProgress,
-        categoryIdsByMangaId: novelCategoryProjection.categoryIdsByMangaId,
+      backupNovels: _withNovelStats(
+        const ChimahonNovelProgressAdapter().exportAll(
+          epubBookProgress,
+          categoryIdsByMangaId: novelCategoryProjection.categoryIdsByMangaId,
+        ),
+        novelStats,
       ),
       backupNovelCategories: novelCategoryProjection.categories,
+      backupMangaStats: const ChimahonStatsAdapter().exportAllMangaStats(
+        mangaStats,
+      ),
+      backupAnkiStats: const ChimahonStatsAdapter().exportAllAnkiStats(
+        ankiStats,
+      ),
     );
+  }
+
+  /// Attaches each book's statistics to its own backup record.
+  ///
+  /// Chimahon nests novel statistics inside `BackupNovel`, keyed by the same
+  /// stable ID the progress adapter produces, so a book with no recorded
+  /// reading simply carries an empty list.
+  List<BackupNovel> _withNovelStats(
+    List<BackupNovel> novels,
+    Map<String, List<NovelStatsEntry>> statsByNovelId,
+  ) {
+    if (statsByNovelId.isEmpty) return novels;
+    const adapter = ChimahonStatsAdapter();
+    return [
+      for (final novel in novels)
+        () {
+          final stats = statsByNovelId[novel.id];
+          if (stats == null || stats.isEmpty) return novel;
+          return novel.deepCopy()
+            ..stats.clear()
+            ..stats.addAll(adapter.exportAllNovelStats(stats));
+        }(),
+    ];
   }
 
   BackupChapter _backupChapter(Chapter chapter, int sourceOrder) {

--- a/test/modules/more/statistics/immersion_stats_data_test.dart
+++ b/test/modules/more/statistics/immersion_stats_data_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/more/statistics/immersion_stats_data.dart';
+import 'package:mangayomi/modules/more/statistics/widgets/immersion_stats_format.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
+
+void main() {
+  // A Saturday, so weekday handling is exercised away from the boundaries.
+  final now = DateTime(2026, 7, 18, 15, 30);
+
+  group('date ranges', () {
+    test('a day is a single date', () {
+      final range = immersionStatsDateRange(
+        ImmersionStatsDateScale.day,
+        0,
+        now: now,
+      );
+      expect(range.start, DateTime(2026, 7, 18));
+      expect(range.end, DateTime(2026, 7, 18));
+    });
+
+    test('a negative day offset moves into the past', () {
+      final range = immersionStatsDateRange(
+        ImmersionStatsDateScale.day,
+        -3,
+        now: now,
+      );
+      expect(range.start, DateTime(2026, 7, 15));
+    });
+
+    test('weeks start on Monday and span seven days', () {
+      final range = immersionStatsDateRange(
+        ImmersionStatsDateScale.week,
+        0,
+        now: now,
+      );
+      expect(range.start.weekday, DateTime.monday);
+      expect(range.start, DateTime(2026, 7, 13));
+      expect(range.end, DateTime(2026, 7, 19));
+    });
+
+    test('a month covers its own length', () {
+      final range = immersionStatsDateRange(
+        ImmersionStatsDateScale.month,
+        0,
+        now: now,
+      );
+      expect(range.start, DateTime(2026, 7, 1));
+      expect(range.end, DateTime(2026, 7, 31));
+    });
+
+    test('stepping back from a long month lands on a valid date', () {
+      // 31 July minus one month must not overflow into 1 July via a 31 June.
+      final range = immersionStatsDateRange(
+        ImmersionStatsDateScale.month,
+        -1,
+        now: DateTime(2026, 7, 31),
+      );
+      expect(range.start, DateTime(2026, 6, 1));
+      expect(range.end, DateTime(2026, 6, 30));
+    });
+
+    test('February is handled including leap years', () {
+      final leap = immersionStatsDateRange(
+        ImmersionStatsDateScale.month,
+        0,
+        now: DateTime(2028, 2, 10),
+      );
+      expect(leap.end, DateTime(2028, 2, 29));
+
+      final common = immersionStatsDateRange(
+        ImmersionStatsDateScale.month,
+        0,
+        now: DateTime(2026, 2, 10),
+      );
+      expect(common.end, DateTime(2026, 2, 28));
+    });
+
+    test('a year spans January to December', () {
+      final range = immersionStatsDateRange(
+        ImmersionStatsDateScale.year,
+        0,
+        now: now,
+      );
+      expect(range.start, DateTime(2026, 1, 1));
+      expect(range.end, DateTime(2026, 12, 31));
+    });
+
+    test('all time reaches back before any possible record', () {
+      final range = immersionStatsDateRange(
+        ImmersionStatsDateScale.allTime,
+        0,
+        now: now,
+      );
+      expect(range.start, DateTime(2000));
+      expect(range.end, DateTime(2026, 7, 18));
+      expect(range.containsKey('2001-01-01'), isTrue);
+    });
+
+    test('containsKey is inclusive at both ends', () {
+      final range = immersionStatsDateRange(
+        ImmersionStatsDateScale.week,
+        0,
+        now: now,
+      );
+      expect(range.containsKey('2026-07-13'), isTrue);
+      expect(range.containsKey('2026-07-19'), isTrue);
+      expect(range.containsKey('2026-07-12'), isFalse);
+      expect(range.containsKey('2026-07-20'), isFalse);
+    });
+  });
+
+  group('date keys', () {
+    test('are zero-padded like Chimahon LocalDate.toString', () {
+      expect(statsDateKey(DateTime(2026, 1, 5)), '2026-01-05');
+      expect(statsDateKey(DateTime(2026, 12, 31)), '2026-12-31');
+    });
+
+    test('sort lexicographically in chronological order', () {
+      final keys = [
+        statsDateKey(DateTime(2026, 12, 1)),
+        statsDateKey(DateTime(2026, 2, 1)),
+        statsDateKey(DateTime(2025, 12, 1)),
+      ]..sort();
+      expect(keys, ['2025-12-01', '2026-02-01', '2026-12-01']);
+    });
+
+    test('parse discards the time component and rejects garbage', () {
+      expect(parseStatsDateKey('2026-07-18'), DateTime(2026, 7, 18));
+      expect(parseStatsDateKey('nonsense'), isNull);
+      expect(parseStatsDateKey(''), isNull);
+    });
+  });
+
+  group('formatting', () {
+    test('counts are grouped with commas', () {
+      expect(formatCount(0), '0');
+      expect(formatCount(999), '999');
+      expect(formatCount(1000), '1,000');
+      expect(formatCount(1234567), '1,234,567');
+      expect(formatCount(-1234), '-1,234');
+    });
+
+    test('elapsed time drops the hour component when there is none', () {
+      expect(formatElapsed(const Duration(seconds: 5)), '00:05');
+      expect(formatElapsed(const Duration(minutes: 3, seconds: 7)), '03:07');
+      expect(
+        formatElapsed(const Duration(hours: 2, minutes: 3, seconds: 7)),
+        '2:03:07',
+      );
+    });
+
+    test('estimates omit leading zero components', () {
+      expect(formatEstimate(45), '45s');
+      expect(formatEstimate(125), '2m 5s');
+      expect(formatEstimate(7325), '2h 2m 5s');
+    });
+
+    test('a non-finite or negative estimate reads as zero', () {
+      expect(formatEstimate(double.infinity), '0s');
+      expect(formatEstimate(double.nan), '0s');
+      expect(formatEstimate(-100), '0s');
+    });
+
+    test('period labels use relative wording for recent periods', () {
+      expect(
+        immersionStatsPeriodLabel(ImmersionStatsDateScale.day, 0, now: now),
+        'Today',
+      );
+      expect(
+        immersionStatsPeriodLabel(ImmersionStatsDateScale.day, -1, now: now),
+        'Yesterday',
+      );
+      expect(
+        immersionStatsPeriodLabel(ImmersionStatsDateScale.day, -5, now: now),
+        'Jul 13',
+      );
+      expect(
+        immersionStatsPeriodLabel(ImmersionStatsDateScale.week, -1, now: now),
+        'Last week',
+      );
+      expect(
+        immersionStatsPeriodLabel(ImmersionStatsDateScale.month, -2, now: now),
+        'May 2026',
+      );
+      expect(
+        immersionStatsPeriodLabel(ImmersionStatsDateScale.year, -2, now: now),
+        '2024',
+      );
+    });
+  });
+
+  test('a query compares by value so providers can cache on it', () {
+    const a = ImmersionStatsQuery(type: ImmersionStatsType.manga, offset: -1);
+    const b = ImmersionStatsQuery(type: ImmersionStatsType.manga, offset: -1);
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+    expect(a.copyWith(offset: -2), isNot(b));
+  });
+
+  test('clearing the profile filter is distinct from leaving it alone', () {
+    const withProfile = ImmersionStatsQuery(profileId: 'ja');
+    // copyWith cannot express "set to null" via the value parameter alone.
+    expect(withProfile.copyWith(offset: -1).profileId, 'ja');
+    expect(withProfile.copyWith(clearProfileId: true).profileId, isNull);
+  });
+}

--- a/test/services/statistics/immersion_stats_storage_test.dart
+++ b/test/services/statistics/immersion_stats_storage_test.dart
@@ -1,0 +1,324 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_storage.dart';
+
+void main() {
+  late Directory directory;
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('immersion_stats_test');
+    Hive.init(directory.path);
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await Hive.close();
+    if (directory.existsSync()) directory.deleteSync(recursive: true);
+  });
+
+  group('manga statistics', () {
+    test('accumulates into one row per day and title', () async {
+      final date = DateTime(2026, 7, 18);
+      await ImmersionStatsStorage.addMangaStats(
+        characters: 100,
+        timeMs: 5000,
+        mangaId: 7,
+        date: date,
+      );
+      await ImmersionStatsStorage.addMangaStats(
+        characters: 50,
+        timeMs: 2000,
+        mangaId: 7,
+        date: date,
+      );
+
+      final stats = await ImmersionStatsStorage.loadMangaStats();
+      expect(stats, hasLength(1));
+      expect(stats.single.charactersRead, 150);
+      expect(stats.single.readingTimeMs, 7000);
+      expect(stats.single.dateKey, '2026-07-18');
+    });
+
+    test('separates days and titles', () async {
+      await ImmersionStatsStorage.addMangaStats(
+        characters: 100,
+        timeMs: 1000,
+        mangaId: 7,
+        date: DateTime(2026, 7, 18),
+      );
+      await ImmersionStatsStorage.addMangaStats(
+        characters: 100,
+        timeMs: 1000,
+        mangaId: 7,
+        date: DateTime(2026, 7, 19),
+      );
+      await ImmersionStatsStorage.addMangaStats(
+        characters: 100,
+        timeMs: 1000,
+        mangaId: 8,
+        date: DateTime(2026, 7, 18),
+      );
+
+      expect(await ImmersionStatsStorage.loadMangaStats(), hasLength(3));
+    });
+
+    test('a page with neither characters nor time is not recorded', () async {
+      await ImmersionStatsStorage.addMangaStats(characters: 0, timeMs: 0);
+      expect(await ImmersionStatsStorage.loadMangaStats(), isEmpty);
+    });
+
+    test('reading with no library entry uses the id-0 bucket', () async {
+      await ImmersionStatsStorage.addMangaStats(characters: 10, timeMs: 100);
+      final stats = await ImmersionStatsStorage.loadMangaStats();
+      expect(stats.single.mangaId, 0);
+    });
+
+    test('merge takes the larger value per field, never the sum', () async {
+      final date = DateTime(2026, 7, 18);
+      await ImmersionStatsStorage.addMangaStats(
+        characters: 100,
+        timeMs: 5000,
+        mangaId: 7,
+        date: date,
+      );
+      // Both fields already synced once; summing would double count the day.
+      await ImmersionStatsStorage.mergeMangaStats([
+        const MangaStatsEntry(
+          dateKey: '2026-07-18',
+          charactersRead: 80,
+          readingTimeMs: 9000,
+          mangaId: 7,
+        ),
+      ]);
+
+      final stats = await ImmersionStatsStorage.loadMangaStats();
+      expect(stats, hasLength(1));
+      expect(stats.single.charactersRead, 100);
+      expect(stats.single.readingTimeMs, 9000);
+    });
+
+    test('merge adds days the device has never seen', () async {
+      await ImmersionStatsStorage.mergeMangaStats([
+        const MangaStatsEntry(dateKey: '2026-07-01', charactersRead: 42),
+      ]);
+      final stats = await ImmersionStatsStorage.loadMangaStats();
+      expect(stats.single.charactersRead, 42);
+    });
+
+    test('concurrent writes do not lose a page', () async {
+      // Read-modify-write under concurrency is exactly how a day's reading gets
+      // silently dropped, so every mutation is serialized.
+      await Future.wait([
+        for (var i = 0; i < 20; i++)
+          ImmersionStatsStorage.addMangaStats(
+            characters: 10,
+            timeMs: 100,
+            mangaId: 7,
+            date: DateTime(2026, 7, 18),
+          ),
+      ]);
+
+      final stats = await ImmersionStatsStorage.loadMangaStats();
+      expect(stats, hasLength(1));
+      expect(stats.single.charactersRead, 200);
+      expect(stats.single.readingTimeMs, 2000);
+    });
+  });
+
+  group('Anki statistics', () {
+    test('counts manga and novel cards separately', () async {
+      final date = DateTime(2026, 7, 18);
+      await ImmersionStatsStorage.addAnkiCard(
+        type: 'manga',
+        profileId: 'ja',
+        date: date,
+      );
+      await ImmersionStatsStorage.addAnkiCard(
+        type: 'manga',
+        profileId: 'ja',
+        date: date,
+      );
+      await ImmersionStatsStorage.addAnkiCard(profileId: 'ja', date: date);
+
+      final stats = await ImmersionStatsStorage.loadAnkiStats();
+      expect(stats, hasLength(1));
+      expect(stats.single.mangaCards, 2);
+      expect(stats.single.novelCards, 1);
+      expect(stats.single.totalCards, 3);
+    });
+
+    test('scopes rows by profile and title', () async {
+      final date = DateTime(2026, 7, 18);
+      await ImmersionStatsStorage.addAnkiCard(profileId: 'ja', date: date);
+      await ImmersionStatsStorage.addAnkiCard(profileId: 'ko', date: date);
+      await ImmersionStatsStorage.addAnkiCard(
+        profileId: 'ja',
+        titleId: 'book',
+        date: date,
+      );
+
+      expect(await ImmersionStatsStorage.loadAnkiStats(), hasLength(3));
+    });
+
+    test('a null titleId is distinct from an empty one', () async {
+      final date = DateTime(2026, 7, 18);
+      await ImmersionStatsStorage.addAnkiCard(profileId: 'ja', date: date);
+      await ImmersionStatsStorage.addAnkiCard(
+        profileId: 'ja',
+        titleId: '',
+        date: date,
+      );
+
+      expect(await ImmersionStatsStorage.loadAnkiStats(), hasLength(2));
+    });
+
+    test('merge takes the larger card count per field', () async {
+      await ImmersionStatsStorage.addAnkiCard(
+        type: 'manga',
+        profileId: 'ja',
+        date: DateTime(2026, 7, 18),
+      );
+      await ImmersionStatsStorage.mergeAnkiStats([
+        const AnkiStatsEntry(
+          dateKey: '2026-07-18',
+          mangaCards: 5,
+          novelCards: 2,
+          profileId: 'ja',
+        ),
+      ]);
+
+      final stats = await ImmersionStatsStorage.loadAnkiStats();
+      expect(stats, hasLength(1));
+      expect(stats.single.mangaCards, 5);
+      expect(stats.single.novelCards, 2);
+    });
+  });
+
+  group('novel statistics', () {
+    test('round-trips per book', () async {
+      await ImmersionStatsStorage.saveNovelStats('book-a', [
+        const NovelStatsEntry(
+          dateKey: '2026-07-18',
+          charactersRead: 900,
+          readingTimeSeconds: 120.5,
+          lastReadingSpeed: 26879,
+        ),
+      ]);
+      await ImmersionStatsStorage.saveNovelStats('book-b', [
+        const NovelStatsEntry(dateKey: '2026-07-18', charactersRead: 100),
+      ]);
+
+      final bookA = await ImmersionStatsStorage.loadNovelStats('book-a');
+      expect(bookA.single.charactersRead, 900);
+      // Fractional seconds must survive: Chimahon stores a double.
+      expect(bookA.single.readingTimeSeconds, 120.5);
+      expect(bookA.single.readingTimeMs, 120500);
+      expect(
+        (await ImmersionStatsStorage.loadNovelStats('book-b')).single
+            .charactersRead,
+        100,
+      );
+    });
+
+    test('loads every book that has statistics', () async {
+      await ImmersionStatsStorage.saveNovelStats('book-a', [
+        const NovelStatsEntry(dateKey: '2026-07-18', charactersRead: 1),
+      ]);
+      await ImmersionStatsStorage.saveNovelStats('book-b', [
+        const NovelStatsEntry(dateKey: '2026-07-18', charactersRead: 2),
+      ]);
+
+      final all = await ImmersionStatsStorage.loadAllNovelStats();
+      expect(all.keys, containsAll(['book-a', 'book-b']));
+    });
+
+    test('merge prefers the newer row and keeps ties local', () async {
+      await ImmersionStatsStorage.saveNovelStats('book', [
+        const NovelStatsEntry(
+          dateKey: '2026-07-18',
+          charactersRead: 500,
+          lastStatisticModified: 100,
+        ),
+        const NovelStatsEntry(
+          dateKey: '2026-07-19',
+          charactersRead: 100,
+          lastStatisticModified: 100,
+        ),
+      ]);
+      await ImmersionStatsStorage.mergeNovelStats('book', [
+        // Newer: wins outright, even though the value is lower.
+        const NovelStatsEntry(
+          dateKey: '2026-07-18',
+          charactersRead: 300,
+          lastStatisticModified: 200,
+        ),
+        // Same clock: a tie keeps the local row.
+        const NovelStatsEntry(
+          dateKey: '2026-07-19',
+          charactersRead: 999,
+          lastStatisticModified: 100,
+        ),
+      ]);
+
+      final byDate = {
+        for (final entry in await ImmersionStatsStorage.loadNovelStats('book'))
+          entry.dateKey: entry,
+      };
+      expect(byDate['2026-07-18']!.charactersRead, 300);
+      expect(byDate['2026-07-19']!.charactersRead, 100);
+    });
+
+    test('deleting a book drops only its statistics', () async {
+      await ImmersionStatsStorage.saveNovelStats('book-a', [
+        const NovelStatsEntry(dateKey: '2026-07-18', charactersRead: 1),
+      ]);
+      await ImmersionStatsStorage.saveNovelStats('book-b', [
+        const NovelStatsEntry(dateKey: '2026-07-18', charactersRead: 2),
+      ]);
+      await ImmersionStatsStorage.deleteNovelStats('book-a');
+
+      expect(await ImmersionStatsStorage.loadNovelStats('book-a'), isEmpty);
+      expect(await ImmersionStatsStorage.loadNovelStats('book-b'), hasLength(1));
+    });
+
+    test('an empty book ID is not persisted', () async {
+      await ImmersionStatsStorage.saveNovelStats('', [
+        const NovelStatsEntry(dateKey: '2026-07-18', charactersRead: 1),
+      ]);
+      expect(await ImmersionStatsStorage.loadAllNovelStats(), isEmpty);
+    });
+  });
+
+  test('a write bumps the revision so the UI can refresh', () async {
+    final before = ImmersionStatsStorage.revision.value;
+    await ImmersionStatsStorage.addMangaStats(characters: 10, timeMs: 100);
+    expect(ImmersionStatsStorage.revision.value, greaterThan(before));
+  });
+
+  test('clear removes every collection', () async {
+    await ImmersionStatsStorage.addMangaStats(characters: 10, timeMs: 100);
+    await ImmersionStatsStorage.addAnkiCard(profileId: 'ja');
+    await ImmersionStatsStorage.saveNovelStats('book', [
+      const NovelStatsEntry(dateKey: '2026-07-18', charactersRead: 1),
+    ]);
+
+    await ImmersionStatsStorage.clear();
+
+    expect(await ImmersionStatsStorage.loadMangaStats(), isEmpty);
+    expect(await ImmersionStatsStorage.loadAnkiStats(), isEmpty);
+    expect(await ImmersionStatsStorage.loadAllNovelStats(), isEmpty);
+  });
+
+  test('a corrupt payload reads as empty rather than throwing', () async {
+    final box = await Hive.openBox<dynamic>(ImmersionStatsStorage.boxName);
+    await box.put('manga_stats', 'not json at all');
+
+    expect(await ImmersionStatsStorage.loadMangaStats(), isEmpty);
+    // The next write repairs the payload.
+    await ImmersionStatsStorage.addMangaStats(characters: 10, timeMs: 100);
+    expect(await ImmersionStatsStorage.loadMangaStats(), hasLength(1));
+  });
+}

--- a/test/services/statistics/novel_statistics_tracker_test.dart
+++ b/test/services/statistics/novel_statistics_tracker_test.dart
@@ -1,0 +1,237 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
+import 'package:mangayomi/services/statistics/novel_statistics_tracker.dart';
+
+void main() {
+  /// A tracker driven by a controllable clock, so the character/time arithmetic
+  /// can be asserted exactly rather than approximately.
+  ({NovelStatisticsTracker tracker, void Function(int seconds) advance})
+  build({List<NovelStatsEntry> initial = const []}) {
+    var now = DateTime(2026, 7, 18, 12);
+    return (
+      tracker: NovelStatisticsTracker(
+        novelId: 'book',
+        initialStatistics: initial,
+        clock: () => now,
+      ),
+      advance: (seconds) => now = now.add(Duration(seconds: seconds)),
+    );
+  }
+
+  test('records characters and time into session, today, and all time', () {
+    final (tracker: tracker, advance: advance) = build();
+    tracker.start(0);
+    advance(60);
+    tracker.update(600);
+
+    final state = tracker.state;
+    expect(state.session.charactersRead, 600);
+    expect(state.session.readingTimeSeconds, 60);
+    // 600 characters in one minute is 36000 characters per hour.
+    expect(state.session.lastReadingSpeed, 36000);
+    expect(state.today.charactersRead, 600);
+    expect(state.allTime.charactersRead, 600);
+  });
+
+  test('a paused tracker records nothing', () {
+    final (tracker: tracker, advance: advance) = build();
+    tracker.start(0);
+    advance(60);
+    tracker.update(600);
+    tracker.pause(600);
+
+    advance(600);
+    tracker.update(1200);
+
+    expect(tracker.state.isTracking, isFalse);
+    expect(tracker.state.session.charactersRead, 600);
+    expect(tracker.state.session.readingTimeSeconds, 60);
+  });
+
+  test('a large jump backwards cannot push the session negative', () {
+    final (tracker: tracker, advance: advance) = build();
+    tracker.start(1000);
+    advance(60);
+    tracker.update(1100);
+    expect(tracker.state.session.charactersRead, 100);
+
+    // Jumping to the start of the book is navigation, not un-reading 1100
+    // characters: it can only cancel what this session counted.
+    advance(10);
+    tracker.update(0);
+    expect(tracker.state.session.charactersRead, 0);
+  });
+
+  test('an idle tick leaves the alternate minimum speed untouched', () {
+    final (tracker: tracker, advance: advance) = build();
+    tracker.start(0);
+    advance(60);
+    tracker.update(600);
+    final speedAfterReading = tracker.state.session.altMinReadingSpeed;
+    expect(speedAfterReading, 36000);
+
+    // Time passing with no characters read would otherwise drag the alternate
+    // minimum toward zero; Chimahon only moves it when characters change.
+    advance(3600);
+    tracker.update(600);
+    expect(tracker.state.session.altMinReadingSpeed, speedAfterReading);
+    // The plain minimum does track the idle period.
+    expect(tracker.state.session.minReadingSpeed, lessThan(speedAfterReading));
+  });
+
+  test('all-time totals include statistics from previous sessions', () {
+    final (tracker: tracker, advance: advance) = build(
+      initial: [
+        const NovelStatsEntry(
+          dateKey: '2026-07-01',
+          charactersRead: 5000,
+          readingTimeSeconds: 1000,
+        ),
+      ],
+    );
+    expect(tracker.state.allTime.charactersRead, 5000);
+
+    tracker.start(0);
+    advance(60);
+    tracker.update(600);
+    expect(tracker.state.allTime.charactersRead, 5600);
+    // Today is a separate day from the stored row, so it starts from zero.
+    expect(tracker.state.today.charactersRead, 600);
+  });
+
+  test('a stored row for today resumes rather than restarting', () {
+    final (tracker: tracker, advance: advance) = build(
+      initial: [
+        const NovelStatsEntry(
+          dateKey: '2026-07-18',
+          charactersRead: 300,
+          readingTimeSeconds: 30,
+        ),
+      ],
+    );
+    expect(tracker.state.today.charactersRead, 300);
+
+    tracker.start(0);
+    advance(60);
+    tracker.update(600);
+    expect(tracker.state.today.charactersRead, 900);
+    expect(tracker.state.session.charactersRead, 600);
+  });
+
+  test('persistence keeps other days and replaces today', () {
+    final (tracker: tracker, advance: advance) = build(
+      initial: [
+        const NovelStatsEntry(dateKey: '2026-07-01', charactersRead: 5000),
+        const NovelStatsEntry(dateKey: '2026-07-18', charactersRead: 300),
+      ],
+    );
+    tracker.start(0);
+    advance(60);
+    tracker.update(600);
+
+    final persisted = tracker.statisticsForPersistence();
+    expect(persisted, hasLength(2));
+    final byDate = {for (final entry in persisted) entry.dateKey: entry};
+    expect(byDate['2026-07-01']!.charactersRead, 5000);
+    expect(byDate['2026-07-18']!.charactersRead, 900);
+  });
+
+  test('duplicate stored days collapse to the most recently modified', () {
+    final (tracker: tracker, advance: _) = build(
+      initial: [
+        const NovelStatsEntry(
+          dateKey: '2026-07-01',
+          charactersRead: 100,
+          lastStatisticModified: 1,
+        ),
+        const NovelStatsEntry(
+          dateKey: '2026-07-01',
+          charactersRead: 900,
+          lastStatisticModified: 2,
+        ),
+      ],
+    );
+
+    final persisted = tracker.statisticsForPersistence();
+    final july1 = persisted.where((entry) => entry.dateKey == '2026-07-01');
+    expect(july1, hasLength(1));
+    expect(july1.single.charactersRead, 900);
+  });
+
+  test('a session spanning midnight splits across both days', () {
+    var now = DateTime(2026, 7, 18, 23, 59);
+    final tracker = NovelStatisticsTracker(
+      novelId: 'book',
+      clock: () => now,
+    );
+    tracker.start(0);
+    now = now.add(const Duration(seconds: 30));
+    tracker.update(300);
+    expect(tracker.state.today.dateKey, '2026-07-18');
+    expect(tracker.state.today.charactersRead, 300);
+
+    // Crossing midnight must open a fresh row rather than crediting the new
+    // day's reading to the old one.
+    now = now.add(const Duration(seconds: 60));
+    tracker.update(600);
+    expect(tracker.state.today.dateKey, '2026-07-19');
+    expect(tracker.state.today.charactersRead, 300);
+    // The session keeps accumulating across the boundary.
+    expect(tracker.state.session.charactersRead, 600);
+
+    // Both days survive persistence.
+    final byDate = {
+      for (final entry in tracker.statisticsForPersistence())
+        entry.dateKey: entry,
+    };
+    expect(byDate.keys, containsAll(['2026-07-18', '2026-07-19']));
+    expect(byDate['2026-07-18']!.charactersRead, 300);
+  });
+
+  test('a disabled tracker ignores every reader tick', () {
+    var now = DateTime(2026, 7, 18, 12);
+    final tracker = NovelStatisticsTracker(
+      novelId: 'book',
+      enabled: false,
+      clock: () => now,
+    );
+    tracker.start(0);
+    now = now.add(const Duration(seconds: 60));
+    tracker.update(600);
+
+    expect(tracker.state.isTracking, isFalse);
+    expect(tracker.state.session.charactersRead, 0);
+    expect(tracker.statisticsForPersistenceOrNull(), isNull);
+  });
+
+  test('resuming after a pause does not bill the paused time', () {
+    final (tracker: tracker, advance: advance) = build();
+    tracker.start(0);
+    advance(60);
+    tracker.update(600);
+    tracker.pause(600);
+
+    // Time away from the reader must not become reading time when it resumes.
+    advance(3600);
+    tracker.start(600);
+    advance(60);
+    tracker.update(1200);
+
+    expect(tracker.state.session.readingTimeSeconds, 120);
+    expect(tracker.state.session.charactersRead, 1200);
+  });
+
+  test('the frozen position holds while paused', () {
+    final (tracker: tracker, advance: advance) = build();
+    tracker.start(0);
+    advance(60);
+    tracker.update(600);
+    tracker.pause(600);
+    expect(tracker.frozenPosition, 600);
+
+    // Page flips during a pause must not move the projection anchor.
+    advance(10);
+    tracker.update(5000);
+    expect(tracker.frozenPosition, 600);
+  });
+}

--- a/test/services/sync/chimahon_generic_collection_safety_audit_test.dart
+++ b/test/services/sync/chimahon_generic_collection_safety_audit_test.dart
@@ -130,7 +130,9 @@ void main() {
     );
   });
 
-  test('global statistics remain exact opaque rows', () {
+  test('global statistics merge per day without losing reading', () {
+    // The same day and title on both devices, each ahead on one field. Chimahon
+    // takes the larger value per field, so one row must survive with both.
     final localManga = BackupMangaStats(
       dateKey: '2026-07-18',
       mangaId: Int64(7),
@@ -167,16 +169,118 @@ void main() {
       proposed: proposed,
     );
 
-    expect(proposed.backupMangaStats, hasLength(2));
-    expect(proposed.backupAnkiStats, hasLength(2));
+    expect(proposed.backupMangaStats, hasLength(1));
+    expect(proposed.backupMangaStats.single.charactersRead, 100);
+    expect(proposed.backupMangaStats.single.readingTime, Int64(90));
+    // Repeated identical rows collapse: they are the same day, profile, and
+    // title, so keeping both would double count the mined cards.
+    expect(proposed.backupAnkiStats, hasLength(1));
+    expect(proposed.backupAnkiStats.single.mangaCards, 3);
     expect(result.failures, isEmpty);
+    expect(result.observations['manga_statistics_merged'], hasLength(1));
+    expect(result.observations['anki_statistics_merged'], hasLength(1));
+  });
+
+  test('fails closed when a merged statistic loses recorded reading', () {
+    final local = BackupMihon(
+      backupMangaStats: [
+        BackupMangaStats(
+          dateKey: '2026-07-18',
+          mangaId: Int64(7),
+          charactersRead: 100,
+          readingTime: Int64(50),
+        ),
+      ],
+      backupAnkiStats: [
+        BackupAnkiStats(
+          dateKey: '2026-07-18',
+          profileId: 'profile',
+          mangaCards: 5,
+        ),
+      ],
+    );
+    // A proposal that reduces either counter has silently erased reading or
+    // mined cards, which the audit must reject rather than upload.
+    final proposed = BackupMihon(
+      backupMangaStats: [
+        BackupMangaStats(
+          dateKey: '2026-07-18',
+          mangaId: Int64(7),
+          charactersRead: 90,
+          readingTime: Int64(50),
+        ),
+      ],
+      backupAnkiStats: [
+        BackupAnkiStats(
+          dateKey: '2026-07-18',
+          profileId: 'profile',
+          mangaCards: 4,
+        ),
+      ],
+    );
+    final result = _run(
+      audit,
+      local: local,
+      remote: BackupMihon(),
+      proposed: proposed,
+    );
+
     expect(
-      result.observations['manga_statistics_manual_backup_only'],
-      hasLength(2),
+      result.failures['local_manga_stat_regressed_in_proposed'],
+      hasLength(1),
     );
     expect(
-      result.observations['anki_statistics_manual_backup_only'],
-      hasLength(2),
+      result.failures['local_anki_stat_regressed_in_proposed'],
+      hasLength(1),
+    );
+  });
+
+  test('fails closed when a statistics day disappears from the proposal', () {
+    final local = BackupMihon(
+      backupMangaStats: [
+        BackupMangaStats(
+          dateKey: '2026-07-18',
+          mangaId: Int64(7),
+          charactersRead: 100,
+        ),
+      ],
+    );
+    final result = _run(
+      audit,
+      local: local,
+      remote: BackupMihon(),
+      proposed: BackupMihon(),
+    );
+
+    expect(
+      result.failures['local_manga_stat_missing_from_proposed'],
+      hasLength(1),
+    );
+  });
+
+  test('an absent Anki titleId is distinct from an empty one', () {
+    // These are different rows: absent means "mined outside any title", while
+    // an empty string is a real (if degenerate) title ID.
+    final withoutTitle = BackupAnkiStats(
+      dateKey: '2026-07-18',
+      profileId: 'profile',
+      novelCards: 2,
+    );
+    final withEmptyTitle = BackupAnkiStats(
+      dateKey: '2026-07-18',
+      profileId: 'profile',
+      novelCards: 4,
+      titleId: '',
+    );
+    final proposed = const ChimahonSyncMerger().merge(
+      local: BackupMihon(backupAnkiStats: [withoutTitle]),
+      remote: BackupMihon(backupAnkiStats: [withEmptyTitle]),
+    );
+
+    expect(proposed.backupAnkiStats, hasLength(2));
+    expect(
+      proposed.backupAnkiStats.map((row) => row.novelCards),
+      containsAll([2, 4]),
     );
   });
 

--- a/test/services/sync/chimahon_stats_adapter_test.dart
+++ b/test/services/sync/chimahon_stats_adapter_test.dart
@@ -1,0 +1,126 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupNovel.pb.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupStatistics.pb.dart';
+import 'package:mangayomi/services/statistics/immersion_stats_models.dart';
+import 'package:mangayomi/services/sync/chimahon_stats_adapter.dart';
+
+void main() {
+  const adapter = ChimahonStatsAdapter();
+
+  group('manga statistics', () {
+    test('round-trips every field', () {
+      const entry = MangaStatsEntry(
+        dateKey: '2026-07-18',
+        charactersRead: 1234,
+        readingTimeMs: 567890,
+        mangaId: 42,
+      );
+
+      expect(adapter.importMangaStats(adapter.exportMangaStats(entry)), entry);
+    });
+
+    test('reading time crosses the wire in milliseconds', () {
+      const entry = MangaStatsEntry(
+        dateKey: '2026-07-18',
+        readingTimeMs: 567890,
+      );
+      expect(adapter.exportMangaStats(entry).readingTime, Int64(567890));
+    });
+
+    test('a row without a date key is dropped in both directions', () {
+      expect(
+        adapter.exportAllMangaStats([
+          const MangaStatsEntry(dateKey: '', charactersRead: 1),
+          const MangaStatsEntry(dateKey: '2026-07-18', charactersRead: 2),
+        ]),
+        hasLength(1),
+      );
+      expect(
+        adapter.importAllMangaStats([
+          BackupMangaStats(dateKey: '', charactersRead: 1),
+          BackupMangaStats(dateKey: '2026-07-18', charactersRead: 2),
+        ]),
+        hasLength(1),
+      );
+    });
+  });
+
+  group('Anki statistics', () {
+    test('round-trips every field', () {
+      const entry = AnkiStatsEntry(
+        dateKey: '2026-07-18',
+        mangaCards: 7,
+        novelCards: 3,
+        profileId: 'ja',
+        titleId: 'book-id',
+      );
+
+      expect(adapter.importAnkiStats(adapter.exportAnkiStats(entry)), entry);
+    });
+
+    test('a null titleId stays absent on the wire', () {
+      const entry = AnkiStatsEntry(dateKey: '2026-07-18', profileId: 'ja');
+      final wire = adapter.exportAnkiStats(entry);
+
+      expect(wire.hasTitleId(), isFalse);
+      expect(adapter.importAnkiStats(wire).titleId, isNull);
+    });
+
+    test('an empty titleId stays present and distinct from absent', () {
+      const entry = AnkiStatsEntry(
+        dateKey: '2026-07-18',
+        profileId: 'ja',
+        titleId: '',
+      );
+      final wire = adapter.exportAnkiStats(entry);
+
+      expect(wire.hasTitleId(), isTrue);
+      expect(adapter.importAnkiStats(wire).titleId, '');
+    });
+  });
+
+  group('novel statistics', () {
+    test('round-trips every field including derived speeds', () {
+      const entry = NovelStatsEntry(
+        dateKey: '2026-07-18',
+        charactersRead: 4321,
+        readingTimeSeconds: 987.5,
+        minReadingSpeed: 1000,
+        altMinReadingSpeed: 1200,
+        lastReadingSpeed: 15750,
+        maxReadingSpeed: 30000,
+        lastStatisticModified: 1784000000000,
+      );
+
+      expect(adapter.importNovelStats(adapter.exportNovelStats(entry)), entry);
+    });
+
+    test('reading time crosses the wire in fractional seconds', () {
+      const entry = NovelStatsEntry(
+        dateKey: '2026-07-18',
+        readingTimeSeconds: 987.5,
+      );
+      // Chimahon's novel stats are a double in seconds, unlike manga's integer
+      // milliseconds; rounding here would lose sub-second reading.
+      expect(adapter.exportNovelStats(entry).readingTime, 987.5);
+    });
+
+    test('a row without a date key is dropped in both directions', () {
+      expect(
+        adapter.exportAllNovelStats([
+          const NovelStatsEntry(dateKey: '', charactersRead: 1),
+          const NovelStatsEntry(dateKey: '2026-07-18', charactersRead: 2),
+        ]),
+        hasLength(1),
+      );
+      expect(
+        adapter.importAllNovelStats([
+          BackupNovelStat(dateKey: '', charactersRead: 1),
+          BackupNovelStat(dateKey: '2026-07-18', charactersRead: 2),
+        ]),
+        hasLength(1),
+      );
+    });
+  });
+}

--- a/test/services/sync/chimahon_stats_row_merge_test.dart
+++ b/test/services/sync/chimahon_stats_row_merge_test.dart
@@ -1,0 +1,190 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupStatistics.pb.dart';
+import 'package:mangayomi/services/sync/chimahon_stats_row_merge.dart';
+
+void main() {
+  group('manga statistics', () {
+    test('the same day and title collapse to the larger value per field', () {
+      final merged = ChimahonStatsRowMerge.mangaStats(
+        [
+          BackupMangaStats(
+            dateKey: '2026-07-18',
+            mangaId: Int64(1),
+            charactersRead: 100,
+            readingTime: Int64(500),
+          ),
+        ],
+        [
+          BackupMangaStats(
+            dateKey: '2026-07-18',
+            mangaId: Int64(1),
+            charactersRead: 80,
+            readingTime: Int64(900),
+          ),
+        ],
+      );
+
+      expect(merged, hasLength(1));
+      expect(merged.single.charactersRead, 100);
+      expect(merged.single.readingTime, Int64(900));
+    });
+
+    test('distinct days and titles stay separate', () {
+      final merged = ChimahonStatsRowMerge.mangaStats(
+        [
+          BackupMangaStats(dateKey: '2026-07-18', mangaId: Int64(1)),
+          BackupMangaStats(dateKey: '2026-07-19', mangaId: Int64(1)),
+        ],
+        [BackupMangaStats(dateKey: '2026-07-18', mangaId: Int64(2))],
+      );
+
+      expect(merged, hasLength(3));
+    });
+
+    test('merging is idempotent', () {
+      final rows = [
+        BackupMangaStats(
+          dateKey: '2026-07-18',
+          mangaId: Int64(1),
+          charactersRead: 100,
+          readingTime: Int64(500),
+        ),
+      ];
+      // Re-running a merge must not keep growing the payload or the counters;
+      // sync uploads the result and merges it again next time.
+      final once = ChimahonStatsRowMerge.mangaStats(rows, rows);
+      final twice = ChimahonStatsRowMerge.mangaStats(once, once);
+
+      expect(twice, hasLength(1));
+      expect(twice.single.charactersRead, 100);
+      expect(twice.single.readingTime, Int64(500));
+    });
+
+    test('both sides future protobuf fields survive', () {
+      final local = BackupMangaStats(dateKey: '2026-07-18', mangaId: Int64(1))
+        ..unknownFields.mergeLengthDelimitedField(900, [1, 2]);
+      final remote = BackupMangaStats(dateKey: '2026-07-18', mangaId: Int64(1))
+        ..unknownFields.mergeLengthDelimitedField(901, [3, 4]);
+
+      final merged = ChimahonStatsRowMerge.mangaStats([local], [remote]).single;
+
+      expect(merged.unknownFields.getField(900)!.lengthDelimited, [
+        [1, 2],
+      ]);
+      expect(merged.unknownFields.getField(901)!.lengthDelimited, [
+        [3, 4],
+      ]);
+    });
+
+    test('the inputs are not mutated', () {
+      final local = BackupMangaStats(
+        dateKey: '2026-07-18',
+        mangaId: Int64(1),
+        charactersRead: 10,
+      );
+      ChimahonStatsRowMerge.mangaStats([local], [
+        BackupMangaStats(
+          dateKey: '2026-07-18',
+          mangaId: Int64(1),
+          charactersRead: 99,
+        ),
+      ]);
+
+      expect(local.charactersRead, 10);
+    });
+  });
+
+  group('Anki statistics', () {
+    test('the same day, profile, and title take the larger counts', () {
+      final merged = ChimahonStatsRowMerge.ankiStats(
+        [
+          BackupAnkiStats(
+            dateKey: '2026-07-18',
+            profileId: 'ja',
+            mangaCards: 7,
+            novelCards: 1,
+          ),
+        ],
+        [
+          BackupAnkiStats(
+            dateKey: '2026-07-18',
+            profileId: 'ja',
+            mangaCards: 3,
+            novelCards: 9,
+          ),
+        ],
+      );
+
+      expect(merged, hasLength(1));
+      expect(merged.single.mangaCards, 7);
+      expect(merged.single.novelCards, 9);
+    });
+
+    test('different profiles stay separate', () {
+      final merged = ChimahonStatsRowMerge.ankiStats(
+        [BackupAnkiStats(dateKey: '2026-07-18', profileId: 'ja')],
+        [BackupAnkiStats(dateKey: '2026-07-18', profileId: 'ko')],
+      );
+
+      expect(merged, hasLength(2));
+    });
+
+    test('an absent titleId does not collide with an empty one', () {
+      final merged = ChimahonStatsRowMerge.ankiStats(
+        [
+          BackupAnkiStats(
+            dateKey: '2026-07-18',
+            profileId: 'ja',
+            novelCards: 2,
+          ),
+        ],
+        [
+          BackupAnkiStats(
+            dateKey: '2026-07-18',
+            profileId: 'ja',
+            novelCards: 4,
+            titleId: '',
+          ),
+        ],
+      );
+
+      expect(merged, hasLength(2));
+      expect(merged.map((row) => row.novelCards), containsAll([2, 4]));
+    });
+
+    test('merging is idempotent', () {
+      final rows = [
+        BackupAnkiStats(
+          dateKey: '2026-07-18',
+          profileId: 'ja',
+          mangaCards: 5,
+        ),
+      ];
+      final twice = ChimahonStatsRowMerge.ankiStats(
+        ChimahonStatsRowMerge.ankiStats(rows, rows),
+        ChimahonStatsRowMerge.ankiStats(rows, rows),
+      );
+
+      expect(twice, hasLength(1));
+      expect(twice.single.mangaCards, 5);
+    });
+  });
+
+  test('an empty side returns the other unchanged', () {
+    final rows = [
+      BackupMangaStats(
+        dateKey: '2026-07-18',
+        mangaId: Int64(1),
+        charactersRead: 42,
+      ),
+    ];
+
+    expect(ChimahonStatsRowMerge.mangaStats(rows, const []), hasLength(1));
+    expect(
+      ChimahonStatsRowMerge.mangaStats(const [], rows).single.charactersRead,
+      42,
+    );
+    expect(ChimahonStatsRowMerge.mangaStats(const [], const []), isEmpty);
+  });
+}

--- a/test/services/sync/chimahon_sync_merger_test.dart
+++ b/test/services/sync/chimahon_sync_merger_test.dart
@@ -1731,7 +1731,7 @@ void main() {
     expect(anime.fetchType, 10);
   });
 
-  test('merges novels while retaining opaque root statistics', () {
+  test('merges novels alongside root statistics', () {
     BackupNovel novel(
       int modified,
       int statModified,
@@ -1788,15 +1788,11 @@ void main() {
     expect(merged.backupNovels.single.stats.single.charactersRead, 250);
     expect(merged.backupNovels.single.categoryIds, ['reading']);
     expect(merged.backupNovels.single.lang, 'ja');
-    expect(merged.backupMangaStats, hasLength(2));
-    expect(
-      merged.backupMangaStats.map((stat) => stat.charactersRead),
-      containsAll([100, 250]),
-    );
-    expect(
-      merged.backupMangaStats.map((stat) => stat.readingTime),
-      containsAll([Int64(200), Int64(180)]),
-    );
+    // The same day and title collapse to one row holding each side's larger
+    // value, so a novel merge does not disturb the manga statistics rule.
+    expect(merged.backupMangaStats, hasLength(1));
+    expect(merged.backupMangaStats.single.charactersRead, 250);
+    expect(merged.backupMangaStats.single.readingTime, Int64(200));
   });
 
   test('does not materialize a synthetic default novel category on a tie', () {
@@ -2087,7 +2083,7 @@ void main() {
     ]);
   });
 
-  test('manga statistics preserve both exact opaque rows', () {
+  test('manga statistics merge per day taking the larger value per field', () {
     final localStat =
         BackupMangaStats(
             dateKey: '2026-07-10',
@@ -2112,24 +2108,44 @@ void main() {
       remote: BackupMihon(backupMangaStats: [remoteStat]),
     );
 
-    expect(merged.backupMangaStats, hasLength(2));
-    final local = merged.backupMangaStats.first;
-    final remote = merged.backupMangaStats.last;
-    expect(local.charactersRead, 100);
-    expect(local.readingTime, Int64(200));
-    expect(local.unknownFields.getField(90)!.varints, [Int64(1)]);
-    expect(local.unknownFields.getField(91)!.lengthDelimited, [
+    // Same day and title: one row, each field at whichever side was ahead.
+    expect(merged.backupMangaStats, hasLength(1));
+    final row = merged.backupMangaStats.single;
+    expect(row.charactersRead, 250);
+    expect(row.readingTime, Int64(200));
+    // Both sides' future protobuf fields must still survive the merge.
+    expect(row.unknownFields.getField(90)!.varints, isNotEmpty);
+    expect(row.unknownFields.getField(91)!.lengthDelimited, [
       [1, 2],
     ]);
-    expect(remote.charactersRead, 250);
-    expect(remote.readingTime, Int64(180));
-    expect(remote.unknownFields.getField(90)!.varints, [Int64(2)]);
-    expect(remote.unknownFields.getField(92)!.lengthDelimited, [
+    expect(row.unknownFields.getField(92)!.lengthDelimited, [
       [3, 4],
     ]);
   });
 
-  test('Anki statistics preserve both exact opaque rows', () {
+  test('manga statistics keep distinct days and titles apart', () {
+    final merged = merger.merge(
+      local: BackupMihon(
+        backupMangaStats: [
+          BackupMangaStats(dateKey: '2026-07-10', mangaId: Int64(1), charactersRead: 10),
+          BackupMangaStats(dateKey: '2026-07-11', mangaId: Int64(1), charactersRead: 20),
+        ],
+      ),
+      remote: BackupMihon(
+        backupMangaStats: [
+          BackupMangaStats(dateKey: '2026-07-10', mangaId: Int64(2), charactersRead: 30),
+        ],
+      ),
+    );
+
+    expect(merged.backupMangaStats, hasLength(3));
+    expect(
+      merged.backupMangaStats.map((row) => row.charactersRead),
+      containsAll([10, 20, 30]),
+    );
+  });
+
+  test('Anki statistics merge per day taking the larger card counts', () {
     final localStat =
         BackupAnkiStats(
             dateKey: '2026-07-10',
@@ -2156,19 +2172,15 @@ void main() {
       remote: BackupMihon(backupAnkiStats: [remoteStat]),
     );
 
-    expect(merged.backupAnkiStats, hasLength(2));
-    final local = merged.backupAnkiStats.first;
-    final remote = merged.backupAnkiStats.last;
-    expect(local.mangaCards, 7);
-    expect(local.novelCards, 3);
-    expect(local.unknownFields.getField(90)!.varints, [Int64(1)]);
-    expect(local.unknownFields.getField(91)!.lengthDelimited, [
+    expect(merged.backupAnkiStats, hasLength(1));
+    final row = merged.backupAnkiStats.single;
+    expect(row.mangaCards, 7);
+    expect(row.novelCards, 9);
+    expect(row.unknownFields.getField(90)!.varints, isNotEmpty);
+    expect(row.unknownFields.getField(91)!.lengthDelimited, [
       [1, 2],
     ]);
-    expect(remote.mangaCards, 5);
-    expect(remote.novelCards, 9);
-    expect(remote.unknownFields.getField(90)!.varints, [Int64(2)]);
-    expect(remote.unknownFields.getField(92)!.lengthDelimited, [
+    expect(row.unknownFields.getField(92)!.lengthDelimited, [
       [3, 4],
     ]);
   });

--- a/test/services/sync/cross_device_sync_engine_test.dart
+++ b/test/services/sync/cross_device_sync_engine_test.dart
@@ -1379,25 +1379,15 @@ void main() {
         contains('Cloud-only novel'),
       );
 
+      // The restored backup, the post-restore local edit, and the cloud record
+      // all describe the same day and title, so they collapse into one row
+      // holding the largest value seen for each field — Chimahon's merge rule.
+      // Keeping three rows would triple count that day's reading.
       final selectedStat = uploaded.backupMangaStats.singleWhere(
-        (stat) =>
-            stat.dateKey == '2026-07-17' &&
-            stat.mangaId == Int64(1) &&
-            stat.charactersRead == 15 &&
-            stat.readingTime == Int64(1500),
+        (stat) => stat.dateKey == '2026-07-17' && stat.mangaId == Int64(1),
       );
-      expect(selectedStat.charactersRead, 15);
-      expect(selectedStat.readingTime, Int64(1500));
-      expect(
-        uploaded.backupMangaStats
-            .where(
-              (stat) =>
-                  stat.dateKey == '2026-07-17' && stat.mangaId == Int64(1),
-            )
-            .map((stat) => (stat.charactersRead, stat.readingTime))
-            .toSet(),
-        {(10, Int64(1000)), (15, Int64(1500)), (99, Int64(9000))},
-      );
+      expect(selectedStat.charactersRead, 99);
+      expect(selectedStat.readingTime, Int64(9000));
       expect(
         uploaded.backupMangaStats.any(
           (stat) => stat.dateKey == '2026-07-18' && stat.mangaId == Int64(42),


### PR DESCRIPTION
Adds full immersion statistics to Mangatan, ported from [Chimahon](https://github.com/sohilsayed/chimahon).

Mangatan could already round-trip Chimahon's statistics rows through sync as opaque bytes, but never produced or displayed them. This implements the feature end to end, keeping Chimahon's schema, units, and arithmetic so the same reading yields the same numbers in both apps and backups restore in either direction.

## What's included

**Tracking**
- **Novel reader** — port of `ReaderStatisticsTracker`: session / today / all-time characters, time, and reading speed, with pause/resume, midnight rollover, and Chimahon's clamping rules (a backwards jump can't push a session negative; an idle tick leaves `altMinReadingSpeed` alone).
- **Manga reader** — per-page dwell time attributed when the page is left, paired with that page's OCR character count. Capped at 120 s per page and deduplicated per chapter. A page whose OCR hasn't finished counts time but no characters, matching Chimahon's `getCachedOcrBlocks`.
- **Anki** — mined cards recorded per media type, dictionary profile, and title on successful export from both dictionary popups.

**UI**
- Immersion statistics screen: All/Manga/Novels scope, Day/Week/Month/Year/All-Time scales with period navigation, dictionary-profile filter, hero duration with a tappable bar chart, and the metric grid (streak, added cards, characters read, avg speed, library, chapters, trackers).
- Searchable, sortable per-title list drilling into single-title statistics.
- In-reader statistics sheets for both readers, with time-to-finish estimates for the chapter and the book.
- The existing library statistics screen is untouched and keeps its own entry in More.

**Backup and sync**
- Statistics now travel as real data: exported into `backupMangaStats`, `backupAnkiStats`, and each `BackupNovel`'s nested `stats`. Manual restore replaces; sync merges.

## Note on one behaviour change

Merging the two global statistics collections switches from exact-byte union to Chimahon's max-per-field rule on its daily `(dateKey, id)` identity.

The old union was correct while these rows were opaque pass-through, but now that they're written daily it would grow the payload without bound and multiply-count a day. Summing isn't an option either — it would double count a day both devices had already synced. Chimahon's own `MangaStatsStorage.merge` / `AnkiStatsStorage.merge` take the larger value per field, which is idempotent and never lowers a counter.

The safety audit was updated to match: it now verifies that every day present on either side survives and that no counter regresses, instead of byte equality. Three existing tests that asserted the opaque behaviour were updated, and the shared rule was factored into `ChimahonStatsRowMerge` so the merger and the pending-restore authority can't drift apart.

## Verification

- `flutter analyze` — no new issues (22 pre-existing warnings/infos, unchanged).
- `flutter test` — 1073 passing. The 12 failures are pre-existing and environmental: `libisar.so` needs a newer GLIBC than this machine has, and one dictionary test reads hardcoded `D:\` paths.
- 74 new tests covering tracker arithmetic, storage concurrency and merge rules, backup round-trips, date-range boundaries (leap years, month-length overflow, ISO weeks), and formatting.

Not manually exercised in a running app — no device/emulator was available in this environment, so the reader instrumentation and screens are verified by tests and analysis only.

## CI reliability

The Android build checkout now initializes Git submodules recursively. Without that, CI reaches Cargo/CMake with an empty `third_party/hoshidicts` tree and fails before compiling the app. This overlaps the checkout change in #64; if #64 lands first, this small workflow hunk can be dropped when the branch is updated.