### PR TITLE
feat(ios): improve Anki and embedded Mihon support

### DIFF
--- a/ios/EmbeddedMihon/THIRD_PARTY_NOTICES.md
+++ b/ios/EmbeddedMihon/THIRD_PARTY_NOTICES.md
@@ -8,8 +8,8 @@ Mangatan's optional embedded Mihon-extension runtime contains:
   <https://github.com/openjdk-mobile/ios-tools>.
 - M-Extension-Server, distributed under the Mozilla Public License 2.0. The
   exact bundled source revision is
-  `e2f662e83f9379eb7a12de3fc1d0917c7a0f61a4` at
-  <https://github.com/ippo-michi/M-Extension-Server>.
+  `9b2cef9d9e9557623e36ab426088f4af94bf0c2c` at
+  <https://github.com/1Selxo/M-Extension-Server>.
 
 The server archive also includes the notices supplied by its dependencies.
 These components are provided without warranty.

--- a/ios/EmbeddedMihon/THIRD_PARTY_NOTICES.md
+++ b/ios/EmbeddedMihon/THIRD_PARTY_NOTICES.md
@@ -8,8 +8,8 @@ Mangatan's optional embedded Mihon-extension runtime contains:
   <https://github.com/openjdk-mobile/ios-tools>.
 - M-Extension-Server, distributed under the Mozilla Public License 2.0. The
   exact bundled source revision is
-  `c151cda985a5e9d9255ba8a59b9c9e4234107983` at
-  <https://github.com/1Selxo/M-Extension-Server>.
+  `e2f662e83f9379eb7a12de3fc1d0917c7a0f61a4` at
+  <https://github.com/ippo-michi/M-Extension-Server>.
 
 The server archive also includes the notices supplied by its dependencies.
 These components are provided without warranty.

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -6,6 +6,9 @@ import Libmtorrentserver
 @objc class AppDelegate: FlutterAppDelegate {
   private static let ankiMobilePasteboardType = "net.ankimobile.json"
   private var ankiMobileMediaBackgroundTask: UIBackgroundTaskIdentifier = .invalid
+  private var embeddedMihonRequested = false
+  private var embeddedMihonNeedsResume = false
+  private var embeddedMihonPort: Int32?
 
   override func application(
     _ application: UIApplication,
@@ -68,12 +71,13 @@ import Libmtorrentserver
       let embeddedMihonChannel = FlutterMethodChannel(
         name: "com.selxo.mangatan.embedded_mihon",
         binaryMessenger: controller.binaryMessenger)
-      embeddedMihonChannel.setMethodCallHandler({
+      embeddedMihonChannel.setMethodCallHandler({ [weak self]
           (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
           switch call.method {
           case "start":
               let args = call.arguments as? [String: Any]
               let port = Int32(args?["port"] as? Int ?? 0)
+              self?.embeddedMihonRequested = true
               MangatanEmbeddedMihonStart(port) { startedPort, error in
                   if let error = error {
                       result(FlutterError(
@@ -81,6 +85,8 @@ import Libmtorrentserver
                         message: error.localizedDescription,
                         details: nil))
                   } else {
+                      self?.embeddedMihonPort = startedPort
+                      self?.embeddedMihonNeedsResume = false
                       result([
                         "port": Int(startedPort),
                         "baseUrl": "http://127.0.0.1:\(startedPort)",
@@ -99,6 +105,9 @@ import Libmtorrentserver
                   }
               }
           case "stop":
+              self?.embeddedMihonRequested = false
+              self?.embeddedMihonNeedsResume = false
+              self?.embeddedMihonPort = nil
               MangatanEmbeddedMihonStop { error in
                   if let error = error {
                       result(FlutterError(
@@ -134,8 +143,31 @@ import Libmtorrentserver
     // Pause from the native lifecycle callback as early as possible. Waiting
     // only for Flutter's inactive notification can let iOS suspend the process
     // while OpenJDK is still blocked in accept(), which spins after wake.
-    MangatanEmbeddedMihonPause { _ in }
+    if embeddedMihonRequested {
+      embeddedMihonNeedsResume = true
+      MangatanEmbeddedMihonPause { _ in }
+    }
     super.applicationWillResignActive(application)
+  }
+
+  override func applicationDidBecomeActive(_ application: UIApplication) {
+    super.applicationDidBecomeActive(application)
+    guard embeddedMihonRequested,
+          embeddedMihonNeedsResume,
+          let port = embeddedMihonPort else {
+      return
+    }
+
+    // Native pause can run before Flutter receives its inactive event. Resume
+    // at the matching native boundary as well, otherwise the Dart reader can
+    // keep valid /image tokens that point at a listener iOS already stopped.
+    MangatanEmbeddedMihonStart(port) { [weak self] startedPort, error in
+      guard let self else { return }
+      if error == nil && startedPort > 0 {
+        self.embeddedMihonPort = startedPort
+        self.embeddedMihonNeedsResume = false
+      }
+    }
   }
 
   private func beginAnkiMobileMediaBackgroundTask() {

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -12,7 +12,7 @@
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Mangatan needs permission to save exported images to your photo library.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Mangatan connects to extension servers and temporarily shares mined images and audio with AnkiMobile.</string>
+	<string>Mangatan connects to extension servers and AnkiConnect, and temporarily shares mined images and audio with AnkiMobile.</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>anki</string>

--- a/lib/eval/mihon/image_proxy.dart
+++ b/lib/eval/mihon/image_proxy.dart
@@ -8,7 +8,8 @@ bool isTransientMihonImageUrl(String url) {
     return true;
   }
 
-  return _isLoopbackMihonImageProxyUri(uri);
+  return _isLoopbackMihonImageProxyUri(uri) ||
+      _isBridgeImageProxyTokenUri(uri);
 }
 
 /// Replaces the bridge server's loopback image origin with the origin the
@@ -70,6 +71,22 @@ bool canReuseCachedMihonPageUrls(Iterable<String>? urls) {
 
 bool _isLoopbackMihonImageProxyUri(Uri uri) {
   return _isLoopbackMihonProxyUri(uri, const {'image'});
+}
+
+bool _isBridgeImageProxyTokenUri(Uri uri) {
+  if (uri.scheme != 'http' && uri.scheme != 'https') return false;
+  if (uri.pathSegments.length != 2 ||
+      uri.pathSegments.first != 'image') {
+    return false;
+  }
+
+  // M-Extension-Server image registrations use UUID tokens. Their URLs remain
+  // valid only while the JVM process that registered them is alive, regardless
+  // of whether the bridge was reached through loopback, LAN, or hosted HTTPS.
+  return RegExp(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+    caseSensitive: false,
+  ).hasMatch(uri.pathSegments.last);
 }
 
 bool _isLoopbackMihonProxyUri(Uri uri, Set<String> routeNames) {

--- a/lib/modules/manga/reader/image_view_vertical.dart
+++ b/lib/modules/manga/reader/image_view_vertical.dart
@@ -5,6 +5,7 @@ import 'package:mangayomi/modules/manga/reader/providers/reader_controller_provi
 import 'package:mangayomi/modules/manga/reader/u_chap_data_preload.dart';
 import 'package:mangayomi/modules/manga/reader/utils/reader_colors.dart';
 import 'package:mangayomi/modules/manga/reader/widgets/color_filter_widget.dart';
+import 'package:mangayomi/eval/mihon/image_proxy.dart';
 import 'package:mangayomi/modules/mining/widgets/reader_ocr_overlay.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -19,6 +20,7 @@ class ImageViewVertical extends ConsumerStatefulWidget {
   final ValueNotifier<bool> isScrolling;
 
   final Function(bool) failedToLoadImage;
+  final VoidCallback? onRefreshMihonPages;
 
   const ImageViewVertical({
     super.key,
@@ -27,6 +29,7 @@ class ImageViewVertical extends ConsumerStatefulWidget {
     required this.failedToLoadImage,
     required this.isHorizontal,
     required this.isScrolling,
+    this.onRefreshMihonPages,
   });
 
   @override
@@ -129,6 +132,18 @@ class _ImageViewVerticalState extends ConsumerState<ImageViewVertical> {
           }
           if (state.extendedImageLoadState == LoadState.failed) {
             widget.failedToLoadImage(true);
+            void retry() {
+              widget.failedToLoadImage(false);
+              final url = widget.data.pageUrl?.url;
+              if (url != null &&
+                  isTransientMihonImageUrl(url) &&
+                  widget.onRefreshMihonPages != null) {
+                widget.onRefreshMihonPages!();
+                return;
+              }
+              state.reLoadImage();
+            }
+
             return Container(
               color: Colors.black,
               height: placeholderHeight,
@@ -145,14 +160,8 @@ class _ImageViewVerticalState extends ConsumerState<ImageViewVertical> {
                   Padding(
                     padding: const EdgeInsets.all(8.0),
                     child: GestureDetector(
-                      onLongPress: () {
-                        state.reLoadImage();
-                        widget.failedToLoadImage(false);
-                      },
-                      onTap: () {
-                        state.reLoadImage();
-                        widget.failedToLoadImage(false);
-                      },
+                      onLongPress: retry,
+                      onTap: retry,
                       child: Container(
                         decoration: BoxDecoration(
                           color: context.primaryColor,

--- a/lib/modules/manga/reader/image_view_webtoon.dart
+++ b/lib/modules/manga/reader/image_view_webtoon.dart
@@ -40,6 +40,7 @@ class ImageViewWebtoon extends StatelessWidget {
   final bool showPageGaps;
   final bool reverse;
   final ValueNotifier<bool> isScrolling;
+  final VoidCallback? onRefreshMihonPages;
 
   const ImageViewWebtoon({
     super.key,
@@ -65,6 +66,7 @@ class ImageViewWebtoon extends StatelessWidget {
     required this.onDoubleTapDown,
     required this.onDoubleTap,
     required this.isScrolling,
+    this.onRefreshMihonPages,
     this.webtoonSidePadding = 0,
     this.showPageGaps = true,
     this.reverse = false,
@@ -178,6 +180,7 @@ class ImageViewWebtoon extends StatelessWidget {
           onLongPressData: onLongPressData,
           isHorizontal: isHorizontalContinuous,
           isScrolling: isScrolling,
+          onRefreshMihonPages: onRefreshMihonPages,
         ),
       ),
     );
@@ -203,6 +206,7 @@ class ImageViewWebtoon extends StatelessWidget {
         backgroundColor: backgroundColor,
         onFailedToLoadImage: onFailedToLoadImage,
         onLongPressData: onLongPressData,
+        onRefreshMihonPages: onRefreshMihonPages,
       ),
     );
   }

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -94,6 +94,7 @@ class _MangaReaderViewState extends ConsumerState<MangaReaderView> {
         }
 
         return MangaChapterPageGallery(
+          key: ObjectKey(model),
           chapter: chapter,
           chapterUrlModel: model,
         );
@@ -317,6 +318,13 @@ class _MangaChapterPageGalleryState
     }
   }
 
+  void _refreshMihonChapterPages() {
+    if (!mounted) return;
+    _failedToLoadImage.value = false;
+    ref.invalidate(getChapterPagesProvider(chapter: chapter));
+    ref.invalidate(mangaReaderProvider(chapter.id));
+  }
+
   // final double _horizontalScaleValue = 1.0;
   bool _isNextChapterPreloading = false;
   int _prefetchSessionId = 0;
@@ -492,6 +500,7 @@ class _MangaChapterPageGalleryState
                                 isHorizontalContinuous &&
                                 readingDirection.isRtl,
                             isScrolling: _isScrolling,
+                            onRefreshMihonPages: _refreshMihonChapterPages,
                           )
                         : Material(
                             color: getBackgroundColor(backgroundColor),
@@ -731,6 +740,7 @@ class _MangaChapterPageGalleryState
           _failedToLoadImage.value = val;
         }
       },
+      onRefreshMihonPages: _refreshMihonChapterPages,
       onLongPressData: (data) {
         ImageActionsDialog.show(
           context: context,

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -320,9 +320,11 @@ class _MangaChapterPageGalleryState
 
   void _refreshMihonChapterPages() {
     if (!mounted) return;
+    final chapterId = chapter.id;
+    if (chapterId == null) return;
     _failedToLoadImage.value = false;
     ref.invalidate(getChapterPagesProvider(chapter: chapter));
-    ref.invalidate(mangaReaderProvider(chapter.id));
+    ref.invalidate(mangaReaderProvider(chapterId));
   }
 
   // final double _horizontalScaleValue = 1.0;

--- a/lib/modules/manga/reader/widgets/double_page_view.dart
+++ b/lib/modules/manga/reader/widgets/double_page_view.dart
@@ -2,6 +2,7 @@ import 'package:extended_image/extended_image.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:mangayomi/main.dart';
+import 'package:mangayomi/eval/mihon/image_proxy.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/manga/reader/image_view_paged.dart';
 import 'package:mangayomi/modules/manga/reader/utils/reader_colors.dart';
@@ -32,6 +33,7 @@ class DoublePageView extends StatefulWidget {
 
   /// Callback for image load failure state.
   final Function(bool)? onFailedToLoadImage;
+  final VoidCallback? onRefreshMihonPages;
 
   /// Whether to use the paged mode (with PhotoView zoom) or vertical mode.
   ///
@@ -51,6 +53,7 @@ class DoublePageView extends StatefulWidget {
     required this.backgroundColor,
     this.onLongPressData,
     this.onFailedToLoadImage,
+    this.onRefreshMihonPages,
     this.isPagedMode = true,
     this.addTopPadding = true,
     this.readingDirection = ReadingDirection.leftToRight,
@@ -63,6 +66,7 @@ class DoublePageView extends StatefulWidget {
     required this.backgroundColor,
     this.onLongPressData,
     this.onFailedToLoadImage,
+    this.onRefreshMihonPages,
     this.readingDirection = ReadingDirection.leftToRight,
   }) : isPagedMode = true,
        addTopPadding = false;
@@ -74,6 +78,7 @@ class DoublePageView extends StatefulWidget {
     required this.backgroundColor,
     this.onLongPressData,
     this.onFailedToLoadImage,
+    this.onRefreshMihonPages,
     this.addTopPadding = true,
     this.readingDirection = ReadingDirection.leftToRight,
   }) : isPagedMode = false;
@@ -277,7 +282,7 @@ class DoublePageViewState extends State<DoublePageView>
           case LoadState.completed:
             return _buildCompletedState(state);
           case LoadState.failed:
-            return _buildFailedState(state, l10n);
+            return _buildFailedState(state, l10n, pageData);
         }
       },
       onLongPressData: onLongPress,
@@ -303,7 +308,11 @@ class DoublePageViewState extends State<DoublePageView>
     return null;
   }
 
-  Widget _buildFailedState(ExtendedImageState state, dynamic l10n) {
+  Widget _buildFailedState(
+    ExtendedImageState state,
+    dynamic l10n,
+    UChapDataPreload pageData,
+  ) {
     widget.onFailedToLoadImage?.call(true);
     final backgroundColor =
         getBackgroundColor(widget.backgroundColor) ??
@@ -323,23 +332,33 @@ class DoublePageViewState extends State<DoublePageView>
           ),
           Padding(
             padding: const EdgeInsets.all(8.0),
-            child: _buildRetryButton(state, l10n),
+            child: _buildRetryButton(state, l10n, pageData),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildRetryButton(ExtendedImageState state, dynamic l10n) {
+  Widget _buildRetryButton(
+    ExtendedImageState state,
+    dynamic l10n,
+    UChapDataPreload pageData,
+  ) {
+    void retry() {
+      widget.onFailedToLoadImage?.call(false);
+      final url = pageData.pageUrl?.url;
+      if (url != null &&
+          isTransientMihonImageUrl(url) &&
+          widget.onRefreshMihonPages != null) {
+        widget.onRefreshMihonPages!();
+        return;
+      }
+      state.reLoadImage();
+    }
+
     return GestureDetector(
-      onLongPress: () {
-        state.reLoadImage();
-        widget.onFailedToLoadImage?.call(false);
-      },
-      onTap: () {
-        state.reLoadImage();
-        widget.onFailedToLoadImage?.call(false);
-      },
+      onLongPress: retry,
+      onTap: retry,
       child: Container(
         decoration: BoxDecoration(
           color: context.primaryColor,

--- a/lib/modules/mining/widgets/dictionary_lookup_popup.dart
+++ b/lib/modules/mining/widgets/dictionary_lookup_popup.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -10,6 +11,7 @@ import 'package:mangayomi/modules/mining/widgets/hoshi_dictionary_popup.dart';
 import 'package:mangayomi/services/hoshidicts/hoshidicts_backend.dart';
 import 'package:mangayomi/services/mining/anki_card_builder.dart';
 import 'package:mangayomi/services/mining/anki_connect_service.dart';
+import 'package:mangayomi/services/mining/anki_mobile_service.dart';
 import 'package:mangayomi/services/mining/dictionary_profile.dart';
 import 'package:mangayomi/services/mining/dictionary_profile_resolver.dart';
 import 'package:mangayomi/services/mining/mining_models.dart';
@@ -1079,23 +1081,40 @@ class _DictionaryLookupResultsViewState
         context: widget.miningContext,
         profile: profile,
       );
-      final noteId =
-          await AnkiConnectService(
-            endpoint: await MiningPreferences.getAnkiEndpoint(),
-          ).exportDraft(
-            draft,
-            duplicateCheck: profile.duplicateCheck,
-            allowDuplicate: dictionaryProfile.duplicateAction == 'allow',
-            duplicateScope: profile.duplicateScope,
-            duplicateDeckNames: profile.duplicateDeckNames,
-            checkAllModels: profile.checkAllModels,
-            syncOnCreate: profile.syncOnCreate,
-          );
+      final preferredMode = await MiningPreferences.getAnkiIntegrationMode();
+      final integrationMode = effectiveAnkiIntegrationMode(
+        preferredMode: preferredMode,
+        isIOS: defaultTargetPlatform == TargetPlatform.iOS,
+      );
+      int? noteId;
+      if (integrationMode == AnkiIntegrationMode.ankiMobile) {
+        await AnkiMobileService().exportDraft(
+          draft,
+          allowDuplicate:
+              !profile.duplicateCheck ||
+              dictionaryProfile.duplicateAction == 'allow',
+        );
+      } else {
+        noteId =
+            await AnkiConnectService(
+              endpoint: await MiningPreferences.getAnkiEndpoint(),
+            ).exportDraft(
+              draft,
+              duplicateCheck: profile.duplicateCheck,
+              allowDuplicate: dictionaryProfile.duplicateAction == 'allow',
+              duplicateScope: profile.duplicateScope,
+              duplicateDeckNames: profile.duplicateDeckNames,
+              checkAllModels: profile.checkAllModels,
+              syncOnCreate: profile.syncOnCreate,
+            );
+      }
       await AnkiStatsRecorder.recordCard(
         context: widget.miningContext,
         profile: dictionaryProfile,
       );
-      botToast('Added to Anki (#$noteId)', second: 3);
+      if (noteId != null) {
+        botToast('Added to Anki (#$noteId)', second: 3);
+      }
     } on AnkiDuplicateException {
       botToast('Already in Anki', second: 3);
     } catch (error) {

--- a/lib/modules/mining/widgets/hoshi_dictionary_popup.dart
+++ b/lib/modules/mining/widgets/hoshi_dictionary_popup.dart
@@ -402,8 +402,18 @@ class _HoshiDictionaryPopupState extends State<HoshiDictionaryPopup> {
     return _entries.length;
   }
 
+  Future<bool> _usesAnkiMobile() async {
+    if (defaultTargetPlatform != TargetPlatform.iOS) return false;
+    final preferredMode = await MiningPreferences.getAnkiIntegrationMode();
+    return effectiveAnkiIntegrationMode(
+          preferredMode: preferredMode,
+          isIOS: true,
+        ) ==
+        AnkiIntegrationMode.ankiMobile;
+  }
+
   Future<bool> _isDuplicate(String expression) async {
-    if (defaultTargetPlatform == TargetPlatform.iOS) return false;
+    if (await _usesAnkiMobile()) return false;
     try {
       final dictionaryProfile = await _resolvedProfile();
       final profile = dictionaryProfile.anki;
@@ -426,7 +436,7 @@ class _HoshiDictionaryPopupState extends State<HoshiDictionaryPopup> {
   }
 
   Future<List<int>> _duplicateNoteIds(String expression) async {
-    if (defaultTargetPlatform == TargetPlatform.iOS) return const [];
+    if (await _usesAnkiMobile()) return const [];
     try {
       final dictionaryProfile = await _resolvedProfile();
       final profile = dictionaryProfile.anki;
@@ -446,7 +456,7 @@ class _HoshiDictionaryPopupState extends State<HoshiDictionaryPopup> {
   }
 
   Future<bool> _browseDuplicateNotes(Object? rawIds) async {
-    if (defaultTargetPlatform == TargetPlatform.iOS) return false;
+    if (await _usesAnkiMobile()) return false;
     final ids = rawIds is Iterable
         ? rawIds
               .map(
@@ -542,7 +552,7 @@ class _HoshiDictionaryPopupState extends State<HoshiDictionaryPopup> {
           !profile.duplicateCheck ||
           content['allowDuplicate'] == true ||
           dictionaryProfile.duplicateAction == 'allow';
-      if (defaultTargetPlatform == TargetPlatform.iOS) {
+      if (await _usesAnkiMobile()) {
         await AnkiMobileService().exportDraft(
           draft,
           allowDuplicate: allowDuplicate,

--- a/lib/modules/more/settings/dictionary/dictionary_screen.dart
+++ b/lib/modules/more/settings/dictionary/dictionary_screen.dart
@@ -59,6 +59,7 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
   AnkiMiningProfile _ankiProfile = const AnkiMiningProfile();
   AnkiAudioPreferences _ankiAudioPreferences = AnkiAudioPreferences.defaults;
   Uri _ankiEndpoint = Uri.parse('http://127.0.0.1:8765');
+  AnkiIntegrationMode _ankiIntegrationMode = AnkiIntegrationMode.ankiMobile;
   int? _ankiVersion;
   List<String> _ankiDecks = const [];
   List<String> _ankiModels = const [];
@@ -67,7 +68,14 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
   String? _ankiError;
   bool _ankiRefreshing = false;
 
-  bool get _usesAnkiMobile => defaultTargetPlatform == TargetPlatform.iOS;
+  bool get _isIOS => defaultTargetPlatform == TargetPlatform.iOS;
+
+  bool get _usesAnkiMobile =>
+      effectiveAnkiIntegrationMode(
+        preferredMode: _ankiIntegrationMode,
+        isIOS: _isIOS,
+      ) ==
+      AnkiIntegrationMode.ankiMobile;
 
   @override
   void initState() {
@@ -98,6 +106,7 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
       MiningPreferences.getActiveDictionaryProfile(),
       MiningPreferences.getMokuroWebsiteOcrEnabled(),
       MiningPreferences.getCropImageBeforeMining(),
+      MiningPreferences.getAnkiIntegrationMode(),
     ]);
     if (!mounted) return;
     setState(() {
@@ -125,6 +134,7 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
       _additionalLeftClick = values[15] as bool;
       _dictionaryLanguage = values[16] as String;
       _cropImageBeforeMining = values[20] as bool;
+      _ankiIntegrationMode = values[21] as AnkiIntegrationMode;
       _loading = false;
     });
     if (widget.section == DictionarySettingsSection.anki && !_usesAnkiMobile) {
@@ -583,6 +593,20 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
     } finally {
       if (mounted) setState(() => _ankiRefreshing = false);
     }
+  }
+
+  Future<void> _setAnkiIntegrationMode(AnkiIntegrationMode mode) async {
+    if (mode == _ankiIntegrationMode) return;
+    setState(() {
+      _ankiIntegrationMode = mode;
+      _ankiVersion = null;
+      _ankiDecks = const [];
+      _ankiModels = const [];
+      _ankiFields = const [];
+      _ankiMobileFieldsByModel = const {};
+      _ankiError = null;
+    });
+    await MiningPreferences.setAnkiIntegrationMode(mode);
   }
 
   Future<void> _selectAnkiModel(String modelName) async {
@@ -1478,7 +1502,52 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
                   _DictionarySettingsGroup.anki,
                 ),
                 const Divider(height: 24),
-                _SectionHeader(_usesAnkiMobile ? 'AnkiMobile' : 'AnkiConnect'),
+                const _SectionHeader('Anki'),
+                if (_isIOS) ...[
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: DropdownButtonFormField<AnkiIntegrationMode>(
+                      key: ValueKey(_ankiIntegrationMode),
+                      initialValue: _ankiIntegrationMode,
+                      decoration: const InputDecoration(
+                        labelText: 'iOS Anki integration',
+                        prefixIcon: Icon(Icons.swap_horiz_outlined),
+                      ),
+                      items: const [
+                        DropdownMenuItem(
+                          value: AnkiIntegrationMode.ankiMobile,
+                          child: Text('AnkiMobile'),
+                        ),
+                        DropdownMenuItem(
+                          value: AnkiIntegrationMode.ankiConnect,
+                          child: Text('AnkiConnect'),
+                        ),
+                      ],
+                      onChanged: (value) {
+                        if (value != null) {
+                          _setAnkiIntegrationMode(value);
+                        }
+                      },
+                    ),
+                  ),
+                  ListTile(
+                    leading: Icon(
+                      _usesAnkiMobile
+                          ? Icons.phone_iphone_outlined
+                          : Icons.lan_outlined,
+                    ),
+                    title: Text(
+                      _usesAnkiMobile
+                          ? 'Use AnkiMobile on this iPhone'
+                          : 'Use an AnkiConnect server',
+                    ),
+                    subtitle: Text(
+                      _usesAnkiMobile
+                          ? 'Opens AnkiMobile through its iOS callback API when you mine a card.'
+                          : 'Connects over HTTP to Anki running on a reachable computer. Use its LAN address, not 127.0.0.1.',
+                    ),
+                  ),
+                ],
                 SwitchListTile(
                   secondary: const Icon(Icons.note_add_outlined),
                   title: const Text('Enable Anki export'),
@@ -1651,7 +1720,15 @@ class _DictionaryScreenState extends State<DictionaryScreen> {
                       final endpoint = value == null
                           ? null
                           : Uri.tryParse(value.trim());
-                      if (endpoint == null || !endpoint.hasScheme) return;
+                      if (endpoint == null ||
+                          !const {'http', 'https'}.contains(endpoint.scheme) ||
+                          endpoint.host.isEmpty) {
+                        botToast(
+                          'Enter a complete http:// or https:// AnkiConnect address',
+                          second: 4,
+                        );
+                        return;
+                      }
                       setState(() => _ankiEndpoint = endpoint);
                       await MiningPreferences.setAnkiEndpoint(endpoint);
                       await _refreshAnki();

--- a/lib/modules/widgets/custom_extended_image_provider.dart
+++ b/lib/modules/widgets/custom_extended_image_provider.dart
@@ -450,7 +450,10 @@ class CustomExtendedNetworkImageProvider
     cancelToken?.throwIfCancellationRequested();
 
     int attempt = 0;
-    var requestUri = resolved;
+    final preparedUrl = await prepareActiveIosMihonProxyUrl(
+      resolved.toString(),
+    );
+    var requestUri = Uri.tryParse(preparedUrl) ?? resolved;
     while (attempt < retries) {
       try {
         return await CancellationTokenSource.register(

--- a/lib/modules/widgets/custom_extended_image_provider.dart
+++ b/lib/modules/widgets/custom_extended_image_provider.dart
@@ -9,6 +9,7 @@ import 'package:flutter/widgets.dart';
 import 'package:http_client_helper/http_client_helper.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/services/http/m_client.dart';
+import 'package:mangayomi/services/m_extension_server.dart';
 import 'package:path/path.dart';
 import 'package:extended_image_library/src/network/extended_network_image_provider.dart'
     as image_provider;
@@ -449,17 +450,26 @@ class CustomExtendedNetworkImageProvider
     cancelToken?.throwIfCancellationRequested();
 
     int attempt = 0;
+    var requestUri = resolved;
     while (attempt < retries) {
       try {
         return await CancellationTokenSource.register(
           cancelToken,
-          _getResponse(resolved),
+          _getResponse(requestUri),
         );
       } catch (e) {
         attempt++;
         if (attempt >= retries) {
           rethrow;
         }
+
+        // The embedded JVM keeps image tokens across listener suspension.
+        // Restart only after a real request failure so healthy page loads do
+        // not perform a capabilities probe for every image.
+        final activeUrl = await resolveActiveIosMihonProxyUrl(
+          requestUri.toString(),
+        );
+        requestUri = Uri.tryParse(activeUrl) ?? requestUri;
 
         // Exponential backoff: 100ms, 200ms, 400ms, 800ms, etc.
         final backoffDelay = Duration(

--- a/lib/services/m_extension_server.dart
+++ b/lib/services/m_extension_server.dart
@@ -55,6 +55,7 @@ class MExtensionServerPlatform {
   static int _lifecycleGeneration = 0;
   static bool _iosAppIsForeground = true;
   static bool _iosBridgeWasRequested = false;
+  static bool _iosBridgeIsReady = false;
   static bool _iosRestartOnResume = false;
   static int? _iosResumePort;
   static int? _preferredRestartPort;
@@ -111,11 +112,15 @@ class MExtensionServerPlatform {
     }
   }
 
-  Future<void> startServer({int? preferredPort}) {
+  Future<void> startServer({
+    int? preferredPort,
+    bool foregroundRequest = false,
+  }) {
     if (Platform.isIOS) {
       _iosBridgeWasRequested = true;
       final lifecycleState = WidgetsBinding.instance.lifecycleState;
-      if (lifecycleState == AppLifecycleState.resumed ||
+      if (foregroundRequest ||
+          lifecycleState == AppLifecycleState.resumed ||
           lifecycleState == null) {
         // Lifecycle notifications and image retries can race during route
         // restoration. Trust Flutter's current state instead of a stale
@@ -158,8 +163,10 @@ class MExtensionServerPlatform {
       final runningBaseUrl = _baseUrl;
       if (_isLoopbackServer(runningBaseUrl) &&
           await _supportsMangatanMihonBridge(runningBaseUrl)) {
+        _iosBridgeIsReady = true;
         return;
       }
+      _iosBridgeIsReady = false;
 
       final runningUri = Uri.tryParse(runningBaseUrl);
       if (_isLoopbackServer(runningBaseUrl) &&
@@ -194,6 +201,7 @@ class MExtensionServerPlatform {
                 deadline: const Duration(seconds: 8),
               )) {
             _writeRuntimeBaseUrl(baseUrl);
+            _iosBridgeIsReady = true;
             _log('Embedded iPhone Mihon bridge is ready at $baseUrl.');
             return;
           }
@@ -214,6 +222,7 @@ class MExtensionServerPlatform {
         '$_embeddedIosLaunchAttempts attempts.',
       );
     } catch (error, stackTrace) {
+      _iosBridgeIsReady = false;
       _restoreSavedBaseUrl();
       if (_isLoopbackServer(_baseUrl)) {
         // A saved desktop loopback URL points back at the iPhone on iOS and
@@ -243,6 +252,7 @@ class MExtensionServerPlatform {
   Future<void> suspendEmbeddedIosBridge() {
     if (!Platform.isIOS) return Future<void>.value();
     _iosAppIsForeground = false;
+    _iosBridgeIsReady = false;
     if (!_iosBridgeWasRequested) return Future<void>.value();
     _iosRestartOnResume = true;
 
@@ -282,6 +292,7 @@ class MExtensionServerPlatform {
       final restarted =
           _isLoopbackServer(_baseUrl) &&
           await _supportsMangatanMihonBridge(_baseUrl);
+      _iosBridgeIsReady = restarted;
       if (_iosAppIsForeground && restarted) {
         _iosRestartOnResume = false;
       } else {
@@ -656,7 +667,7 @@ Future<String> prepareActiveIosMihonProxyUrl(String url) async {
   // Wake the bridge before the first restored reader request. Concurrent
   // pages await the same pending launch; later healthy requests take this
   // synchronous fast path and avoid per-image capability probes.
-  if (MExtensionServerPlatform._iosBridgeWasRequested &&
+  if (MExtensionServerPlatform._iosBridgeIsReady &&
       !MExtensionServerPlatform._iosRestartOnResume &&
       MExtensionServerPlatform._pendingStart == null) {
     return url;
@@ -675,6 +686,7 @@ Future<String> resolveActiveIosMihonProxyUrl(String url) async {
     preferredPort: proxyUri.hasPort && proxyUri.port > 0
         ? proxyUri.port
         : null,
+    foregroundRequest: true,
   );
   final baseUrl = server.baseUrl;
   if (baseUrl == MExtensionServerPlatform._unavailableBaseUrl ||

--- a/lib/services/m_extension_server.dart
+++ b/lib/services/m_extension_server.dart
@@ -650,6 +650,20 @@ class MExtensionServerPlatform {
 /// Restarts the embedded listener before a reader retries a transient Mihon
 /// image URL. Image tokens live in the retained JVM, so only the loopback
 /// origin needs to be updated if iOS could not reclaim the previous port.
+Future<String> prepareActiveIosMihonProxyUrl(String url) async {
+  if (!Platform.isIOS || !isTransientMihonImageUrl(url)) return url;
+
+  // Wake the bridge before the first restored reader request. Concurrent
+  // pages await the same pending launch; later healthy requests take this
+  // synchronous fast path and avoid per-image capability probes.
+  if (MExtensionServerPlatform._iosBridgeWasRequested &&
+      !MExtensionServerPlatform._iosRestartOnResume &&
+      MExtensionServerPlatform._pendingStart == null) {
+    return url;
+  }
+  return resolveActiveIosMihonProxyUrl(url);
+}
+
 Future<String> resolveActiveIosMihonProxyUrl(String url) async {
   if (!Platform.isIOS || !isTransientMihonImageUrl(url)) return url;
 

--- a/lib/services/m_extension_server.dart
+++ b/lib/services/m_extension_server.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:m_extension_server/m_extension_server.dart';
+import 'package:mangayomi/eval/mihon/image_proxy.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/source.dart';
@@ -60,6 +61,7 @@ class MExtensionServerPlatform {
   static final List<DateTime> _automaticRestartHistory = [];
   static String Function()? _stableReadBaseUrl;
   static void Function(String)? _stableWriteBaseUrl;
+  static MExtensionServerPlatform? _stableInstance;
 
   late final String Function() _readBaseUrl;
   late final void Function(String) _writeBaseUrl;
@@ -75,6 +77,7 @@ class MExtensionServerPlatform {
     if (persistent) {
       _stableReadBaseUrl = _readBaseUrl;
       _stableWriteBaseUrl = _writeBaseUrl;
+      _stableInstance = this;
     }
   }
 
@@ -265,8 +268,13 @@ class MExtensionServerPlatform {
       final resumePort = _iosResumePort;
       _iosResumePort = null;
       await startServer(preferredPort: resumePort);
-      if (_iosAppIsForeground) {
+      final restarted =
+          _isLoopbackServer(_baseUrl) &&
+          await _supportsMangatanMihonBridge(_baseUrl);
+      if (_iosAppIsForeground && restarted) {
         _iosRestartOnResume = false;
+      } else {
+        _iosRestartOnResume = true;
       }
     });
   }
@@ -626,6 +634,29 @@ class MExtensionServerPlatform {
     AppLogger.log(message, logLevel: level);
     if (kDebugMode) debugPrint(message);
   }
+}
+
+/// Restarts the embedded listener before a reader retries a transient Mihon
+/// image URL. Image tokens live in the retained JVM, so only the loopback
+/// origin needs to be updated if iOS could not reclaim the previous port.
+Future<String> resolveActiveIosMihonProxyUrl(String url) async {
+  if (!Platform.isIOS || !isTransientMihonImageUrl(url)) return url;
+
+  final server = MExtensionServerPlatform._stableInstance;
+  final proxyUri = Uri.tryParse(url);
+  if (server == null || proxyUri == null) return url;
+
+  await server.startServer(
+    preferredPort: proxyUri.hasPort && proxyUri.port > 0
+        ? proxyUri.port
+        : null,
+  );
+  final baseUrl = server.baseUrl;
+  if (baseUrl == MExtensionServerPlatform._unavailableBaseUrl ||
+      !server._isLoopbackServer(baseUrl)) {
+    return url;
+  }
+  return resolveMihonImageUrl(baseUrl, url);
 }
 
 Future<String> prepareMihonBridge(Ref ref, Source? source) async {

--- a/lib/services/m_extension_server.dart
+++ b/lib/services/m_extension_server.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:http/http.dart' as http;
 import 'package:m_extension_server/m_extension_server.dart';
 import 'package:mangayomi/eval/mihon/image_proxy.dart';
@@ -113,6 +114,16 @@ class MExtensionServerPlatform {
   Future<void> startServer({int? preferredPort}) {
     if (Platform.isIOS) {
       _iosBridgeWasRequested = true;
+      final lifecycleState = WidgetsBinding.instance.lifecycleState;
+      if (lifecycleState == AppLifecycleState.resumed ||
+          lifecycleState == null) {
+        // Lifecycle notifications and image retries can race during route
+        // restoration. Trust Flutter's current state instead of a stale
+        // notification cached before the route became visible.
+        _iosAppIsForeground = true;
+      } else {
+        _iosAppIsForeground = false;
+      }
       if (!_iosAppIsForeground) {
         _iosRestartOnResume = true;
         return Future<void>.value();
@@ -653,7 +664,8 @@ Future<String> resolveActiveIosMihonProxyUrl(String url) async {
   );
   final baseUrl = server.baseUrl;
   if (baseUrl == MExtensionServerPlatform._unavailableBaseUrl ||
-      !server._isLoopbackServer(baseUrl)) {
+      !server._isLoopbackServer(baseUrl) ||
+      !await server._supportsMangatanMihonBridge(baseUrl)) {
     return url;
   }
   return resolveMihonImageUrl(baseUrl, url);
@@ -666,9 +678,16 @@ Future<String> prepareMihonBridge(Ref ref, Source? source) async {
     await server.startServer();
   }
   final baseUrl = server.baseUrl;
-  if ((isDesktop || Platform.isIOS) &&
-      source?.sourceCodeLanguage == SourceCodeLanguage.mihon &&
-      baseUrl == MExtensionServerPlatform._unavailableBaseUrl) {
+  final requiresMihonBridge =
+      (isDesktop || Platform.isIOS) &&
+      source?.sourceCodeLanguage == SourceCodeLanguage.mihon;
+  final unusableIosLoopback =
+      Platform.isIOS &&
+      server._isLoopbackServer(baseUrl) &&
+      !await server._supportsMangatanMihonBridge(baseUrl);
+  if (requiresMihonBridge &&
+      (baseUrl == MExtensionServerPlatform._unavailableBaseUrl ||
+          unusableIosLoopback)) {
     throw const MihonBridgeUnavailableException();
   }
   return baseUrl;

--- a/lib/services/mining/mining_preferences.dart
+++ b/lib/services/mining/mining_preferences.dart
@@ -20,6 +20,22 @@ DictionaryLookupTrigger dictionaryLookupTriggerFromName(String? name) {
   );
 }
 
+enum AnkiIntegrationMode { ankiMobile, ankiConnect }
+
+AnkiIntegrationMode ankiIntegrationModeFromName(String? name) {
+  return AnkiIntegrationMode.values.firstWhere(
+    (value) => value.name == name,
+    orElse: () => AnkiIntegrationMode.ankiMobile,
+  );
+}
+
+AnkiIntegrationMode effectiveAnkiIntegrationMode({
+  required AnkiIntegrationMode preferredMode,
+  required bool isIOS,
+}) {
+  return isIOS ? preferredMode : AnkiIntegrationMode.ankiConnect;
+}
+
 enum AnkiAudioSourceType {
   japanesePod101,
   jisho,
@@ -281,6 +297,7 @@ class MiningPreferences {
   static const _jimakuApiKey = 'jimaku_api_key';
   static const _autoJimaku = 'auto_jimaku';
   static const _ankiEndpoint = 'anki_endpoint';
+  static const _ankiIntegrationMode = 'anki_integration_mode';
   static const _ankiProfile = 'anki_profile';
   static const _dictionaryProfiles = 'dictionary_profiles';
   static const _activeDictionaryProfileId = 'active_dictionary_profile_id';
@@ -579,6 +596,20 @@ class MiningPreferences {
 
   static Future<void> setAnkiEndpoint(Uri value) async {
     await (await _boxOrNull())?.put(_ankiEndpoint, value.toString());
+  }
+
+  static Future<AnkiIntegrationMode> getAnkiIntegrationMode() async {
+    final raw =
+        (await _boxOrNull())?.get(
+              _ankiIntegrationMode,
+              defaultValue: AnkiIntegrationMode.ankiMobile.name,
+            )
+            as String?;
+    return ankiIntegrationModeFromName(raw);
+  }
+
+  static Future<void> setAnkiIntegrationMode(AnkiIntegrationMode value) async {
+    await (await _boxOrNull())?.put(_ankiIntegrationMode, value.name);
   }
 
   static Future<AnkiMiningProfile> getAnkiProfile() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mangayomi
 description: Free and open source manga reader and anime streaming
   cross-plateform app inspired by Tachiyomi and Aniyomi.
 publish_to: "none"
-version: 1.0.9+155
+version: 1.0.9+156
 
 environment:
   sdk: ^3.12.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mangayomi
 description: Free and open source manga reader and anime streaming
   cross-plateform app inspired by Tachiyomi and Aniyomi.
 publish_to: "none"
-version: 1.0.9+160
+version: 1.0.9+161
 
 environment:
   sdk: ^3.12.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mangayomi
 description: Free and open source manga reader and anime streaming
   cross-plateform app inspired by Tachiyomi and Aniyomi.
 publish_to: "none"
-version: 1.0.9+161
+version: 1.0.9+162
 
 environment:
   sdk: ^3.12.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mangayomi
 description: Free and open source manga reader and anime streaming
   cross-plateform app inspired by Tachiyomi and Aniyomi.
 publish_to: "none"
-version: 1.0.9+158
+version: 1.0.9+159
 
 environment:
   sdk: ^3.12.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mangayomi
 description: Free and open source manga reader and anime streaming
   cross-plateform app inspired by Tachiyomi and Aniyomi.
 publish_to: "none"
-version: 1.0.9+159
+version: 1.0.9+160
 
 environment:
   sdk: ^3.12.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mangayomi
 description: Free and open source manga reader and anime streaming
   cross-plateform app inspired by Tachiyomi and Aniyomi.
 publish_to: "none"
-version: 1.0.9+156
+version: 1.0.9+157
 
 environment:
   sdk: ^3.12.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mangayomi
 description: Free and open source manga reader and anime streaming
   cross-plateform app inspired by Tachiyomi and Aniyomi.
 publish_to: "none"
-version: 1.0.9+157
+version: 1.0.9+158
 
 environment:
   sdk: ^3.12.2

--- a/test/eval/mihon/image_proxy_test.dart
+++ b/test/eval/mihon/image_proxy_test.dart
@@ -36,6 +36,22 @@ void main() {
       );
     });
 
+    test('recognizes bridge UUID tokens through LAN and hosted origins', () {
+      const token = '6e7a9ad0-a45a-4cb7-8b34-e83cdd38c985';
+      expect(
+        isTransientMihonImageUrl(
+          'http://192.168.2.112:8080/image/$token',
+        ),
+        isTrue,
+      );
+      expect(
+        isTransientMihonImageUrl(
+          'https://bridge.example/image/$token',
+        ),
+        isTrue,
+      );
+    });
+
     test('recognizes legacy Mokuro CBZ-entry URLs as transient', () {
       expect(
         isTransientMihonImageUrl(
@@ -81,7 +97,10 @@ void main() {
     });
 
     test('persists transient URLs for metadata but never reuses them', () {
-      final proxyUrls = ['http://127.0.0.1:39641/image/token'];
+      final proxyUrls = [
+        'http://192.168.2.112:8080/image/'
+            '6e7a9ad0-a45a-4cb7-8b34-e83cdd38c985',
+      ];
       final ordinaryUrls = ['https://cdn.example/001.jpg'];
 
       expect(canReuseCachedMihonPageUrls(proxyUrls), isFalse);

--- a/test/services/m_extension_server_test.dart
+++ b/test/services/m_extension_server_test.dart
@@ -134,6 +134,16 @@ void main() {
     );
     expect(
       serviceSource,
+      contains('foregroundRequest: true'),
+      reason: 'an active reader request must bypass stale inactive state',
+    );
+    expect(
+      serviceSource,
+      contains('MExtensionServerPlatform._iosBridgeIsReady'),
+      reason: 'a failed launch must not suppress the next reader wake-up',
+    );
+    expect(
+      serviceSource,
       contains('!await server._supportsMangatanMihonBridge(baseUrl)'),
       reason: 'a dead saved loopback address must never be returned as ready',
     );

--- a/test/services/m_extension_server_test.dart
+++ b/test/services/m_extension_server_test.dart
@@ -98,6 +98,16 @@ void main() {
       reason: 'native pause must begin before iOS suspends the Dart isolate',
     );
     expect(
+      appDelegateSource,
+      contains('applicationDidBecomeActive'),
+      reason: 'a listener paused natively must also resume natively',
+    );
+    expect(
+      appDelegateSource,
+      contains('MangatanEmbeddedMihonStart(port)'),
+      reason: 'existing image tokens must regain their original loopback port',
+    );
+    expect(
       serviceSource,
       contains("invokeMethod<bool>('status')"),
       reason: 'a stale native listener must be detected before restart',
@@ -106,6 +116,22 @@ void main() {
       serviceSource,
       contains("invokeMethod<void>('pause')"),
       reason: 'app suspension must preserve loaded extension instances',
+    );
+    expect(
+      serviceSource,
+      contains('Future<String> resolveActiveIosMihonProxyUrl(String url)'),
+      reason: 'reader image retries must heal a stopped loopback listener',
+    );
+    final imageProviderSource = File(
+      'lib/modules/widgets/custom_extended_image_provider.dart',
+    ).readAsStringSync();
+    expect(
+      imageProviderSource,
+      contains(
+        'resolveActiveIosMihonProxyUrl(\n'
+        '          requestUri.toString(),',
+      ),
+      reason: 'transient reader images must restart the bridge before HTTP',
     );
     expect(
       nativeSource,

--- a/test/services/m_extension_server_test.dart
+++ b/test/services/m_extension_server_test.dart
@@ -122,6 +122,16 @@ void main() {
       contains('Future<String> resolveActiveIosMihonProxyUrl(String url)'),
       reason: 'reader image retries must heal a stopped loopback listener',
     );
+    expect(
+      serviceSource,
+      contains('WidgetsBinding.instance.lifecycleState'),
+      reason: 'a stale lifecycle notification must not block a visible reader',
+    );
+    expect(
+      serviceSource,
+      contains('!await server._supportsMangatanMihonBridge(baseUrl)'),
+      reason: 'a dead saved loopback address must never be returned as ready',
+    );
     final imageProviderSource = File(
       'lib/modules/widgets/custom_extended_image_provider.dart',
     ).readAsStringSync();

--- a/test/services/m_extension_server_test.dart
+++ b/test/services/m_extension_server_test.dart
@@ -124,6 +124,11 @@ void main() {
     );
     expect(
       serviceSource,
+      contains('Future<String> prepareActiveIosMihonProxyUrl(String url)'),
+      reason: 'restored reader pages must wake the bridge before first HTTP',
+    );
+    expect(
+      serviceSource,
       contains('WidgetsBinding.instance.lifecycleState'),
       reason: 'a stale lifecycle notification must not block a visible reader',
     );
@@ -135,6 +140,14 @@ void main() {
     final imageProviderSource = File(
       'lib/modules/widgets/custom_extended_image_provider.dart',
     ).readAsStringSync();
+    expect(
+      imageProviderSource,
+      contains(
+        'prepareActiveIosMihonProxyUrl(\n'
+        '      resolved.toString(),',
+      ),
+      reason: 'the first restored reader request must start the bridge',
+    );
     expect(
       imageProviderSource,
       contains(

--- a/test/services/mining/mining_preferences_profile_test.dart
+++ b/test/services/mining/mining_preferences_profile_test.dart
@@ -48,6 +48,40 @@ void main() {
     });
   });
 
+  test('defaults to AnkiMobile and persists the selected iOS mode', () async {
+    expect(
+      await MiningPreferences.getAnkiIntegrationMode(),
+      AnkiIntegrationMode.ankiMobile,
+    );
+
+    await MiningPreferences.setAnkiIntegrationMode(
+      AnkiIntegrationMode.ankiConnect,
+    );
+    await Hive.box<dynamic>('mining_preferences').close();
+
+    expect(
+      await MiningPreferences.getAnkiIntegrationMode(),
+      AnkiIntegrationMode.ankiConnect,
+    );
+  });
+
+  test('desktop always resolves to AnkiConnect', () {
+    expect(
+      effectiveAnkiIntegrationMode(
+        preferredMode: AnkiIntegrationMode.ankiMobile,
+        isIOS: false,
+      ),
+      AnkiIntegrationMode.ankiConnect,
+    );
+    expect(
+      effectiveAnkiIntegrationMode(
+        preferredMode: AnkiIntegrationMode.ankiMobile,
+        isIOS: true,
+      ),
+      AnkiIntegrationMode.ankiMobile,
+    );
+  });
+
   test('uses and persists ordered Japanese audio sources', () async {
     final defaults = await MiningPreferences.getAnkiAudioPreferences();
     expect(defaults.effectiveSources.map((source) => source.type), [

--- a/tool/prepare_embedded_mihon_ios.sh
+++ b/tool/prepare_embedded_mihon_ios.sh
@@ -9,9 +9,11 @@ lazy_framework_dir="$repo_dir/ios/Frameworks/OpenJDKRuntime.framework"
 work_dir=$(mktemp -d "${TMPDIR:-/tmp}/mangatan-embedded-mihon.XXXXXX")
 trap 'find "$work_dir" -depth -delete' EXIT
 
-server_commit="c151cda985a5e9d9255ba8a59b9c9e4234107983"
-server_jar_url="https://github.com/1Selxo/M-Extension-Server/releases/download/ios-runtime-v4/MExtensionServer-ios.jar"
-server_jar_sha256="1c8c325601c540fb6453cf84db7ab747ba03c6f3e960334017d2563f543bcc5b"
+# Keep the current Mihon/TachiyomiX bytecode repairs while avoiding jdk.zipfs,
+# which is intentionally absent from the small embedded iOS JRE.
+server_commit="e2f662e83f9379eb7a12de3fc1d0917c7a0f61a4"
+server_jar_url="https://github.com/ippo-michi/M-Extension-Server/releases/download/ios-runtime-v5/MExtensionServer-ios.jar"
+server_jar_sha256="2245649a4bdf2303b7a19f23dfadd36eddbde441808f38b32d3c2dd468ef20c6"
 openjdk_framework_url="https://github.com/1Selxo/Mangatan/releases/download/embedded-openjdk-ios13-v15/OpenJDK.xcframework.zip"
 openjdk_framework_sha256="24589886361678b369e4703d82fcb3deff1b40728d725fef4fea7e70cb728f55"
 openjdk_bundle_url="https://github.com/1Selxo/Mangatan/releases/download/embedded-openjdk-ios13-v15/java_bundle-device.zip"

--- a/tool/prepare_embedded_mihon_ios.sh
+++ b/tool/prepare_embedded_mihon_ios.sh
@@ -11,9 +11,9 @@ trap 'find "$work_dir" -depth -delete' EXIT
 
 # Keep the current Mihon/TachiyomiX bytecode repairs while avoiding jdk.zipfs,
 # which is intentionally absent from the small embedded iOS JRE.
-server_commit="e2f662e83f9379eb7a12de3fc1d0917c7a0f61a4"
-server_jar_url="https://github.com/ippo-michi/M-Extension-Server/releases/download/ios-runtime-v5/MExtensionServer-ios.jar"
-server_jar_sha256="2245649a4bdf2303b7a19f23dfadd36eddbde441808f38b32d3c2dd468ef20c6"
+server_commit="9b2cef9d9e9557623e36ab426088f4af94bf0c2c"
+server_jar_url="https://github.com/1Selxo/M-Extension-Server/releases/download/ios-runtime-v5/MExtensionServer-ios.jar"
+server_jar_sha256="f1bee201f10ab7a94f89078f15f781f80cc794c0accf11b04a27752a8605b791"
 openjdk_framework_url="https://github.com/1Selxo/Mangatan/releases/download/embedded-openjdk-ios13-v15/OpenJDK.xcframework.zip"
 openjdk_framework_sha256="24589886361678b369e4703d82fcb3deff1b40728d725fef4fea7e70cb728f55"
 openjdk_bundle_url="https://github.com/1Selxo/Mangatan/releases/download/embedded-openjdk-ios13-v15/java_bundle-device.zip"


### PR DESCRIPTION
## Summary

- let iOS users choose AnkiMobile callbacks or AnkiConnect while preserving desktop behavior
- make embedded iOS Mihon bridge recover after suspension, stale listeners, and not-yet-ready startup
- refresh transient Mihon image tokens and harden reader chapter restoration
- pin iOS server runtime and project/release links to 1Selxo upstream repositories

## Validation

- tested build 162 on a physical iPhone running iOS 26.5.2
- app startup, embedded bridge startup, /capabilities, source browsing, chapter loading, and image-token refresh work
- git diff --check passes
- no Mangatan release was built or published from this PR branch

## Known source issue

MangaFire image requests currently reach embedded bridge, but remote image host returns HTTP 522. This is being diagnosed separately from iOS bridge/runtime changes.