### PR TITLE
Fix the Mihon extension server on Arch Linux, and package it for the AUR

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -7,6 +7,13 @@ on:
         description: Stable Mangatan release tag to publish
         required: true
         type: string
+      extension_server_tag:
+        description: >-
+          M-Extension-Server tag for mangatan-extension-server, or blank for its
+          latest stable release
+        required: false
+        default: ""
+        type: string
     secrets:
       AUR_SSH_PRIVATE_KEY:
         required: true
@@ -14,6 +21,13 @@ on:
     inputs:
       release_tag:
         description: Stable tag to publish, or blank for the latest release
+        required: false
+        default: ""
+        type: string
+      extension_server_tag:
+        description: >-
+          M-Extension-Server tag for mangatan-extension-server, or blank for its
+          latest stable release
         required: false
         default: ""
         type: string
@@ -138,4 +152,113 @@ jobs:
 
           git -C aur-repository commit \
             -m "Update to ${RELEASE_TAG#v}"
+          git -C aur-repository push origin HEAD:master
+
+  # The extension server versions independently of Mangatan, so this usually
+  # finds the AUR already up to date and exits without pushing. It runs
+  # regardless of the app job's outcome because neither package depends on the
+  # other's contents.
+  publish-extension-server:
+    runs-on: ubuntu-24.04
+    env:
+      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+    steps:
+      - name: require AUR publishing key
+        shell: bash
+        run: |
+          if [[ -z "$AUR_SSH_PRIVATE_KEY" ]]; then
+            echo "::error::Add the AUR SSH private key as the AUR_SSH_PRIVATE_KEY repository secret."
+            exit 1
+          fi
+
+      - name: resolve extension server release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ inputs.extension_server_tag }}
+        run: |
+          server_tag=$REQUESTED_TAG
+          if [[ -z "$server_tag" ]]; then
+            # /releases/latest excludes prereleases, which is what keeps the
+            # ios-runtime-vN tags in this repository out of the AUR.
+            server_tag=$(gh api \
+              repos/1Selxo/M-Extension-Server/releases/latest \
+              --jq .tag_name)
+          fi
+
+          if [[ ! $server_tag =~ ^v[0-9]+([.][0-9]+)*$ ]]; then
+            echo "::error::Expected a stable vX.Y.Z-style extension server tag, got: $server_tag"
+            exit 1
+          fi
+
+          printf 'SERVER_TAG=%s\n' "$server_tag" >> "$GITHUB_ENV"
+          printf 'Publishing M-Extension-Server %s to the AUR\n' "$server_tag"
+
+      - name: checkout packaging source
+        uses: actions/checkout@v7
+
+      - name: render AUR package
+        shell: bash
+        run: |
+          scripts/render_aur_extension_server.sh \
+            "$SERVER_TAG" \
+            aur-package
+
+      - name: generate AUR metadata
+        shell: bash
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE/aur-package:/pkg:ro" \
+            --workdir /pkg \
+            archlinux:base-devel \
+            runuser -u nobody -- env \
+              HOME=/tmp \
+              BUILDDIR=/tmp/makepkg-build \
+              SRCDEST=/tmp/makepkg-sources \
+              PKGDEST=/tmp/makepkg-packages \
+              makepkg --printsrcinfo \
+            > aur-package/.SRCINFO
+
+          grep -Fx 'pkgbase = mangatan-extension-server' aur-package/.SRCINFO
+          grep -Fx "	pkgver = ${SERVER_TAG#v}" aur-package/.SRCINFO
+
+      - name: configure AUR SSH access
+        shell: bash
+        run: |
+          install -dm700 "$HOME/.ssh"
+          install -m600 /dev/null "$HOME/.ssh/aur"
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$HOME/.ssh/aur"
+          printf '%s\n' \
+            'aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN' \
+            > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/known_hosts"
+
+      - name: publish AUR package
+        shell: bash
+        env:
+          GIT_SSH_COMMAND: >-
+            ssh -i ~/.ssh/aur -o IdentitiesOnly=yes
+            -o StrictHostKeyChecking=yes
+        run: |
+          git clone \
+            ssh://aur@aur.archlinux.org/mangatan-extension-server.git \
+            aur-repository
+
+          install -m644 aur-package/PKGBUILD aur-repository/PKGBUILD
+          install -m644 aur-package/.SRCINFO aur-repository/.SRCINFO
+          install -m644 aur-package/LICENSE aur-repository/LICENSE
+
+          git -C aur-repository config user.name "Mangatan release bot"
+          git -C aur-repository config user.email \
+            "10378052+bee-san@users.noreply.github.com"
+          git -C aur-repository config commit.gpgsign false
+          git -C aur-repository add PKGBUILD .SRCINFO LICENSE
+
+          if git -C aur-repository diff --cached --quiet; then
+            echo "AUR package is already up to date."
+            exit 0
+          fi
+
+          git -C aur-repository commit \
+            -m "Update to ${SERVER_TAG#v}"
           git -C aur-repository push origin HEAD:master

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -828,6 +828,12 @@
   "selected_folder_does_not_exist": "The selected folder does not exist.",
   "no_extension_server_files_found_in_selected_folder": "No extension server files were found in the selected folder.",
   "extension_server_files_linked": "Extension server files were linked.",
+  "extension_server_directory_is_package_managed": "The extension server folder is managed by your package manager. Installing into {fallbackDirectory} instead.",
+  "@extension_server_directory_is_package_managed": {
+    "placeholders": {
+      "fallbackDirectory": {}
+    }
+  },
   "select_extension_server_jar": "Select extension server JAR",
   "selected_file_could_not_be_accessed": "The selected file could not be accessed.",
   "extension_server_jar_imported": "Extension server JAR was imported.",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -4229,6 +4229,14 @@ abstract class AppLocalizations {
   /// **'Extension server files were linked.'**
   String get extension_server_files_linked;
 
+  /// No description provided for @extension_server_directory_is_package_managed.
+  ///
+  /// In en, this message translates to:
+  /// **'The extension server folder is managed by your package manager. Installing into {fallbackDirectory} instead.'**
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  );
+
   /// No description provided for @select_extension_server_jar.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -2289,6 +2289,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get extension_server_files_linked => 'تم ربط ملفات خادم الإضافات.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar => 'اختر ملف JAR لخادم الامتداد';
 
   @override

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -2287,6 +2287,13 @@ class AppLocalizationsAs extends AppLocalizations {
       'Extension server files were linked.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar => 'Select extension server JAR';
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -2301,6 +2301,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Extension Server-Dateien wurden verknüpft.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar => 'Erweiterungsserver-JAR auswählen';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -2280,6 +2280,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Extension server files were linked.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar => 'Select extension server JAR';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -2310,6 +2310,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Archivos del servidor vinculados.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar =>
       'Seleccionar JAR del servidor de extensiones';
 

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -2309,6 +2309,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Extension server files were linked.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar =>
       'Sélectionner le JAR du serveur d\'extension';
 

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -2284,6 +2284,13 @@ class AppLocalizationsHi extends AppLocalizations {
       'Extension server files were linked.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar => 'एक्सटेंशन सर्वर JAR चुनें';
 
   @override

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -2289,6 +2289,13 @@ class AppLocalizationsId extends AppLocalizations {
       'File server ekstensi telah ditautkan.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar => 'Pilih JAR server ekstensi';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -2309,6 +2309,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'File del server estensioni collegati.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar =>
       'Seleziona JAR del server estensioni';
 

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -2251,6 +2251,13 @@ class AppLocalizationsJa extends AppLocalizations {
       'Extension server files were linked.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar => 'Select extension server JAR';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -2305,6 +2305,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Arquivos do servidor vinculados.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar =>
       'Selecionar JAR do servidor de extensão';
 

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -2319,6 +2319,13 @@ class AppLocalizationsRu extends AppLocalizations {
       'Файлы сервера расширений привязаны.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar => 'Выбрать JAR-файл сервера';
 
   @override

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -2280,6 +2280,13 @@ class AppLocalizationsTh extends AppLocalizations {
       'Extension server files were linked.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar => 'Select extension server JAR';
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -2291,6 +2291,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Eklenti sunucusu dosyaları bağlandı.';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar =>
       'Eklenti sunucusu JAR dosyasını seçin';
 

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2216,6 +2216,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get extension_server_files_linked => '扩展服务器文件已链接。';
 
   @override
+  String extension_server_directory_is_package_managed(
+    Object fallbackDirectory,
+  ) {
+    return 'The extension server folder is managed by your package manager. Installing into $fallbackDirectory instead.';
+  }
+
+  @override
   String get select_extension_server_jar => '选择扩展服务器 JAR';
 
   @override

--- a/lib/modules/more/settings/browse/extension_server/extension_server_utils.dart
+++ b/lib/modules/more/settings/browse/extension_server/extension_server_utils.dart
@@ -26,12 +26,22 @@ const extensionServerSystemDirectories = <String>[
 
 /// Whether [directory] is a package-managed location that the in-app installer
 /// must not write to or wipe.
+///
+/// Matches an ancestor of a managed directory as well as the directory itself,
+/// because the installer wipes its target with `delete(recursive: true)`. The
+/// folder picker resolves the JAR recursively, so selecting `/usr/share/mangatan`
+/// — or `/usr` — yields a working configuration whose next in-app update would
+/// recursively delete everything beneath it. Subdirectories are covered too,
+/// since they are equally package-owned.
 bool isManagedExtensionServerDirectory(String directory) {
   if (directory.isEmpty) return false;
-  // path.equals canonicalizes both sides, so a trailing separator or a `..`
-  // segment cannot slip a package-owned path past this check.
+  // path.equals/isWithin canonicalize both sides, so a trailing separator or a
+  // `..` segment cannot slip a package-owned path past this check.
   return extensionServerSystemDirectories.any(
-    (managed) => path.equals(managed, directory),
+    (managed) =>
+        path.equals(managed, directory) ||
+        path.isWithin(directory, managed) ||
+        path.isWithin(managed, directory),
   );
 }
 

--- a/lib/modules/more/settings/browse/extension_server/extension_server_utils.dart
+++ b/lib/modules/more/settings/browse/extension_server/extension_server_utils.dart
@@ -11,6 +11,70 @@ const extensionServerReleaseApiUrl =
 const apkBridgeReleaseUrl =
     'https://github.com/Schnitzel5/ApkBridge/releases/latest';
 
+/// Distro-managed install locations for the extension server, newest layout
+/// first. A Linux package (for example the `mangatan-extension-server` AUR
+/// package) drops `MExtensionServer-<version>.jar` plus a `jre/jre/bin/java`
+/// symlink to the system JRE here, so the bridge works without the user
+/// pointing the file picker at anything.
+///
+/// These directories are owned by the package manager. Never extract into or
+/// delete them; see [isManagedExtensionServerDirectory].
+const extensionServerSystemDirectories = <String>[
+  '/usr/share/mangatan/extension_server',
+  '/usr/lib/mangatan/extension_server',
+];
+
+/// Whether [directory] is a package-managed location that the in-app installer
+/// must not write to or wipe.
+bool isManagedExtensionServerDirectory(String directory) {
+  if (directory.isEmpty) return false;
+  // path.equals canonicalizes both sides, so a trailing separator or a `..`
+  // segment cannot slip a package-owned path past this check.
+  return extensionServerSystemDirectories.any(
+    (managed) => path.equals(managed, directory),
+  );
+}
+
+/// Finds a package-managed extension server install, or null when none is
+/// usable. Linux-only: no other platform ships a distro package.
+///
+/// A candidate only counts when it provides *both* a `java` executable and a
+/// `MExtensionServer-*.jar`, so a partially removed package is skipped rather
+/// than persisted as a broken configuration.
+///
+/// [directories] exists so tests can point at a temporary tree instead of the
+/// real `/usr` paths; production callers use the default.
+Future<SystemExtensionServerPaths?> findSystemExtensionServer({
+  List<String> directories = extensionServerSystemDirectories,
+}) async {
+  if (!Platform.isLinux) return null;
+  for (final candidate in directories) {
+    final root = Directory(candidate);
+    if (!await root.exists()) continue;
+    // Reuses the same resolution the folder picker performs. Note the packaged
+    // `java` must sit at `<root>/jre/jre/bin/java`: that preferred path is
+    // probed with File.exists(), which follows symlinks, whereas the recursive
+    // fallback lists with followLinks: false and would skip a symlink.
+    final jrePath = await findExtensionServerJavaExecutable(root);
+    if (jrePath == null) continue;
+    final jarPath = await findExtensionServerJar(root);
+    if (jarPath == null) continue;
+    return SystemExtensionServerPaths(jrePath: jrePath, jarPath: jarPath);
+  }
+  return null;
+}
+
+/// A resolved pair of paths from a package-managed extension server install.
+class SystemExtensionServerPaths {
+  final String jrePath;
+  final String jarPath;
+
+  const SystemExtensionServerPaths({
+    required this.jrePath,
+    required this.jarPath,
+  });
+}
+
 String? extensionServerDirectoryFromPaths({
   required String jrePath,
   required String extensionServerPath,

--- a/lib/modules/more/settings/browse/extension_server_screen.dart
+++ b/lib/modules/more/settings/browse/extension_server_screen.dart
@@ -385,7 +385,7 @@ class _ExtensionServerScreenState extends ConsumerState<ExtensionServerScreen> {
     final wasInstalled = _isInstalled;
     try {
       await _downloadReleaseBundle(release, bundleZip, l10n);
-      final installDir = await _resolveInstallDirectory();
+      final installDir = await _resolveDownloadDirectory(l10n);
       await MExtensionServerPlatform(ref).stopServer();
       await _installDownloadedBundle(bundleZip, installDir, l10n);
       await _startServerAndRefresh();
@@ -521,6 +521,24 @@ class _ExtensionServerScreenState extends ConsumerState<ExtensionServerScreen> {
       return Directory(_selectedInstallDirectory);
     }
     return _defaultInstallDirectory();
+  }
+
+  /// Like [_resolveInstallDirectory], but never returns a package-managed
+  /// directory: installing there would wipe a pacman-owned tree (the install
+  /// clears the target first) and the files would be lost on the next upgrade.
+  /// The selected directory becomes package-managed whenever the bridge adopted
+  /// a distro install, so this is the normal case, not an edge case.
+  Future<Directory> _resolveDownloadDirectory(dynamic l10n) async {
+    final installDir = await _resolveInstallDirectory();
+    if (!isManagedExtensionServerDirectory(installDir.path)) {
+      return installDir;
+    }
+    final fallback = await _defaultInstallDirectory();
+    botToast(
+      l10n.extension_server_directory_is_package_managed(fallback.path),
+      second: 5,
+    );
+    return fallback;
   }
 
   Future<Directory> _defaultInstallDirectory() async {
@@ -747,6 +765,14 @@ class _ExtensionServerScreenState extends ConsumerState<ExtensionServerScreen> {
   }
 
   Future<void> _prepareInstallDirectory(Directory installDir) async {
+    // Last line of defence for the recursive delete below: callers are expected
+    // to have gone through _resolveDownloadDirectory already.
+    if (isManagedExtensionServerDirectory(installDir.path)) {
+      throw Exception(
+        'Refusing to install into the package-managed directory '
+        '"${installDir.path}".',
+      );
+    }
     if (await installDir.exists()) {
       await _deleteDirectoryWithRetry(installDir);
     }

--- a/lib/services/m_extension_server.dart
+++ b/lib/services/m_extension_server.dart
@@ -11,6 +11,7 @@ import 'package:mangayomi/eval/mihon/image_proxy.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/source.dart';
+import 'package:mangayomi/modules/more/settings/browse/extension_server/extension_server_utils.dart';
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
 import 'package:mangayomi/utils/log/logger.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
@@ -40,8 +41,26 @@ String? embeddedMihonBaseUrlFromResponse(Map<Object?, Object?>? response) {
   return 'http://127.0.0.1:$port';
 }
 
+/// Extracts the feature (major) version from `java -version` output.
+///
+/// Handles both the modern scheme (`"21.0.12"` -> 21) and the legacy `1.x`
+/// scheme (`"1.8.0_452"` -> 8). Returns null when no version is present.
+@visibleForTesting
+int? parseJreMajorVersion(String output) {
+  final match = RegExp(r'version\s+"(\d+)(?:\.(\d+))?').firstMatch(output);
+  if (match == null) return null;
+  final first = int.tryParse(match.group(1)!);
+  if (first == null) return null;
+  if (first != 1) return first;
+  return int.tryParse(match.group(2) ?? '');
+}
+
 class MExtensionServerPlatform {
   static const _unavailableBaseUrl = 'http://127.0.0.1:0';
+
+  /// The server JAR's entry point is Java 21 bytecode (class file major 65)
+  /// outside META-INF/versions, so an older runtime cannot load it at all.
+  static const _minimumJreMajorVersion = 21;
   static const _embeddedIosChannel = MethodChannel(
     'com.selxo.mangatan.embedded_mihon',
   );
@@ -334,16 +353,37 @@ class MExtensionServerPlatform {
 
       _setBaseUrl(_unavailableBaseUrl);
       final settings = isar.settings.getSync(227);
-      final jrePath = settings?.jrePath ?? '';
-      final serverJarPath = settings?.extensionServerPath ?? '';
+      var jrePath = settings?.jrePath ?? '';
+      var serverJarPath = settings?.extensionServerPath ?? '';
       if (isDesktop &&
           (!await _isFile(jrePath) || !await _isFile(serverJarPath))) {
+        // Nothing configured (or the configured files went away). A distro
+        // package may have installed the server system-wide, in which case
+        // adopt it instead of making the user pick the folder by hand.
+        final system = await findSystemExtensionServer();
+        if (system == null) {
+          _log(
+            'Mihon bridge was not started because the configured JRE or JAR '
+            'does not exist. JRE: "$jrePath", JAR: "$serverJarPath".',
+            level: LogLevel.error,
+          );
+          return;
+        }
+        jrePath = system.jrePath;
+        serverJarPath = system.jarPath;
         _log(
-          'Mihon bridge was not started because the configured JRE or JAR '
-          'does not exist. JRE: "$jrePath", JAR: "$serverJarPath".',
-          level: LogLevel.error,
+          'Adopted the package-managed Mihon extension server at '
+          '"${path.dirname(serverJarPath)}".',
         );
-        return;
+        _persistResolvedServerPaths(jrePath, serverJarPath);
+      }
+
+      if (Platform.isLinux) {
+        final incompatibility = await _describeJreIncompatibility(jrePath);
+        if (incompatibility != null) {
+          _log(incompatibility, level: LogLevel.error);
+          return;
+        }
       }
 
       for (var attempt = 1; attempt <= _launchAttempts; attempt++) {
@@ -483,6 +523,49 @@ class MExtensionServerPlatform {
 
   Future<bool> _isFile(String filePath) async {
     return filePath.isNotEmpty && await File(filePath).exists();
+  }
+
+  void _persistResolvedServerPaths(String jrePath, String serverJarPath) {
+    final settings = isar.settings.getSync(227);
+    if (settings == null) return;
+    isar.writeTxnSync(
+      () => isar.settings.putSync(
+        settings
+          ..jrePath = jrePath
+          ..extensionServerPath = serverJarPath
+          ..updatedAt = DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+
+  /// Returns an actionable error when [jrePath] is too old to run the server
+  /// JAR, or null when it looks usable (including when the version can't be
+  /// determined — never block a launch on a failed probe).
+  ///
+  /// Worth the extra process spawn on Linux: the plugin redirects the JVM's
+  /// stdout and stderr to /dev/null, so an UnsupportedClassVersionError would
+  /// otherwise surface only as three silent 20-second readiness timeouts.
+  Future<String?> _describeJreIncompatibility(String jrePath) async {
+    final version = await _readJreMajorVersion(jrePath);
+    if (version == null || version >= _minimumJreMajorVersion) return null;
+    return 'The Mihon bridge was not started because "$jrePath" is Java '
+        '$version, but the extension server requires Java '
+        '$_minimumJreMajorVersion or newer. Install a supported runtime (on '
+        'Arch Linux: pacman -S jre$_minimumJreMajorVersion-openjdk) or use '
+        'Settings > Browse > Extension server to download the bundled runtime.';
+  }
+
+  Future<int?> _readJreMajorVersion(String jrePath) async {
+    try {
+      final result = await Process.run(jrePath, [
+        '-version',
+      ]).timeout(const Duration(seconds: 10));
+      // `java -version` writes to stderr for historical reasons; older builds
+      // and some wrappers use stdout, so scan both.
+      return parseJreMajorVersion('${result.stderr}\n${result.stdout}');
+    } catch (_) {
+      return null;
+    }
   }
 
   Future<int> _allocatePort() async {

--- a/packaging/arch/PKGBUILD-extension-server.template
+++ b/packaging/arch/PKGBUILD-extension-server.template
@@ -1,0 +1,67 @@
+# Maintainer: Autumn (Bee) <10378052+bee-san at users dot noreply dot github dot com>
+
+pkgname=mangatan-extension-server
+pkgver=@SERVERVER@
+pkgrel=1
+pkgdesc="Headless Mihon extension server for Mangatan (Mihon bridge)"
+# The JAR is byte-identical in the upstream Linux, macOS and Windows bundles and
+# ships JNI natives for every architecture, so it is portable as-is.
+arch=('any')
+url="https://github.com/1Selxo/M-Extension-Server"
+license=('MPL-2.0')
+
+makedepends=('libarchive')
+# Pin the runtime rather than using java-runtime>=21: only jre21-openjdk (or
+# jdk21-openjdk, which provides it) guarantees the exact interpreter path linked
+# below. A newer JVM satisfies java-runtime>=21 but installs elsewhere, which
+# would leave that symlink dangling.
+depends=('jre21-openjdk')
+
+_bundle="${pkgname}-${pkgver}-bundle.zip"
+_jar="MExtensionServer-v${pkgver}.jar"
+_serverdir="usr/share/mangatan/extension_server"
+
+source=(
+  "${_bundle}::${url}/releases/download/v${pkgver}/linux-x64-bundle.zip"
+  "LICENSE-${pkgver}::https://raw.githubusercontent.com/1Selxo/M-Extension-Server/v${pkgver}/LICENSE"
+)
+# Upstream publishes no standalone JAR asset, only the four ~135 MiB platform
+# bundles. Skip the automatic extraction so the vendored JRE inside never lands
+# on disk; prepare() pulls out the one file this package installs.
+noextract=("${_bundle}")
+
+sha256sums=(
+  '@SERVER_SHA256@'
+  '@SERVER_LICENSE_SHA256@'
+)
+
+prepare() {
+  # Renamed from the upstream MExtensionServer-v<ver>-r1.jar: Mangatan only
+  # requires the MExtensionServer- prefix, the .jar suffix and a parseable
+  # version in the basename, so dropping the build-number suffix keeps the
+  # packaged name stable if upstream bumps it.
+  bsdtar --extract --to-stdout --file "${_bundle}" 'MExtensionServer-*.jar' \
+    > "${_jar}"
+
+  # bsdtar reports a missing pattern via its exit status, but a glob matching an
+  # unexpected extra entry would silently concatenate archives.
+  if (( $(stat -c %s "${_jar}") < 10000000 )); then
+    printf 'Extracted %s is implausibly small\n' "${_jar}" >&2
+    return 1
+  fi
+}
+
+package() {
+  install -Dm644 "${srcdir}/${_jar}" "${pkgdir}/${_serverdir}/${_jar}"
+
+  # Mangatan looks for the interpreter at exactly <root>/jre/jre/bin/java, the
+  # layout of the upstream bundle it normally downloads. Linking the system JRE
+  # there lets the app adopt this install with no folder picking, and keeps the
+  # ~135 MiB vendored runtime out of the package.
+  install -dm755 "${pkgdir}/${_serverdir}/jre/jre/bin"
+  ln -s /usr/lib/jvm/java-21-openjdk/bin/java \
+    "${pkgdir}/${_serverdir}/jre/jre/bin/java"
+
+  install -Dm644 "${srcdir}/LICENSE-${pkgver}" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/packaging/arch/PKGBUILD-extension-server.template
+++ b/packaging/arch/PKGBUILD-extension-server.template
@@ -36,6 +36,17 @@ sha256sums=(
 )
 
 prepare() {
+  # bsdtar fails on a pattern that matches nothing, but a pattern matching two
+  # entries would concatenate them into one corrupt file and still exit 0, so
+  # require exactly one match before extracting rather than after.
+  local matches
+  matches=$(bsdtar --list --file "${_bundle}" 'MExtensionServer-*.jar' | wc -l)
+  if (( matches != 1 )); then
+    printf 'Expected exactly one MExtensionServer JAR in %s, matched %s\n' \
+      "${_bundle}" "${matches}" >&2
+    return 1
+  fi
+
   # Renamed from the upstream MExtensionServer-v<ver>-r1.jar: Mangatan only
   # requires the MExtensionServer- prefix, the .jar suffix and a parseable
   # version in the basename, so dropping the build-number suffix keeps the
@@ -43,8 +54,6 @@ prepare() {
   bsdtar --extract --to-stdout --file "${_bundle}" 'MExtensionServer-*.jar' \
     > "${_jar}"
 
-  # bsdtar reports a missing pattern via its exit status, but a glob matching an
-  # unexpected extra entry would silently concatenate archives.
   if (( $(stat -c %s "${_jar}") < 10000000 )); then
     printf 'Extracted %s is implausibly small\n' "${_jar}" >&2
     return 1

--- a/packaging/arch/PKGBUILD.template
+++ b/packaging/arch/PKGBUILD.template
@@ -28,6 +28,7 @@ depends=(
   'mpv'
   'pango'
   'webkit2gtk-4.1'
+  'xdg-user-dirs'
   'xdg-utils'
   'zlib-ng-compat'
 )

--- a/packaging/arch/PKGBUILD.template
+++ b/packaging/arch/PKGBUILD.template
@@ -33,6 +33,10 @@ depends=(
   'zlib-ng-compat'
 )
 
+optdepends=(
+  'mangatan-extension-server: Mihon extension support via the Mihon bridge'
+)
+
 provides=('mangatan' 'mangayomi')
 conflicts=(
   'mangatan'

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -1,7 +1,31 @@
 # AUR publishing
 
-Each successful stable Mangatan release publishes `mangatan-bin` to the AUR.
-Private and prerelease releases are excluded.
+Each successful stable Mangatan release publishes two AUR packages. Private and
+prerelease releases are excluded.
+
+| Package | Template | Versioned by |
+| --- | --- | --- |
+| `mangatan-bin` | `PKGBUILD.template` | the Mangatan release tag |
+| `mangatan-extension-server` | `PKGBUILD-extension-server.template` | the latest stable [M-Extension-Server](https://github.com/1Selxo/M-Extension-Server) tag |
+
+`mangatan-extension-server` is an `optdepends` of `mangatan-bin`: it provides
+Mihon extension support (the "Mihon bridge") and is not needed to read local or
+Mangayomi-sourced content. Installing it means the bridge works with no trip
+through Settings, because Mangatan discovers
+`/usr/share/mangatan/extension_server` on startup.
+
+It carries only the ~100 MiB server JAR and depends on `jre21-openjdk` rather
+than vendoring the ~135 MiB JRE that upstream's bundle ships. The JAR is
+byte-identical across upstream's Linux, macOS and Windows bundles and contains
+JNI natives for every architecture, so the package is `arch=any` — which also
+makes the bridge available on aarch64, where the in-app download has no asset.
+
+Two naming constraints are load-bearing and will silently break detection if
+changed: the installed JAR must keep the `MExtensionServer-` prefix with a `.jar`
+suffix, and must retain a parseable `vX.Y.Z` in its basename or the app reports
+version `1.0.0` and offers a perpetual bogus update. The `java` symlink must sit
+at exactly `jre/jre/bin/java` under the server directory, mirroring the layout of
+the bundle the app would otherwise download.
 
 ## One-time setup
 
@@ -18,23 +42,43 @@ Private and prerelease releases are excluded.
 5. Delete both local key files after storing the private key somewhere secure,
    or retain them in a password manager for recovery.
 
-The next stable release will update the `mangatan-bin` AUR repository. To
-publish an existing release without rebuilding Mangatan, run the
-`Publish AUR package` workflow manually. Leave the tag blank for the latest
-stable release or enter a tag such as `v1.0.9`.
+6. Register both package bases on the AUR. The workflow pushes to existing
+   repositories and does not create them.
+
+The next stable release will update both AUR repositories. To publish an
+existing release without rebuilding Mangatan, run the `Publish AUR package`
+workflow manually. Leave a tag blank for the latest stable release, or enter one
+such as `v1.0.9`; the two tags are independent.
 
 ## What the workflow does
 
-The workflow downloads `SHA256SUMS-linux.txt` from the GitHub release, renders
-`PKGBUILD.template`, fetches checksums for the tagged desktop file and license,
-generates `.SRCINFO` with the current Arch `makepkg`, and pushes only
-`PKGBUILD`, `.SRCINFO`, and the 0BSD packaging license to the AUR.
+The `publish` job downloads `SHA256SUMS-linux.txt` from the GitHub release,
+renders `PKGBUILD.template`, and fetches checksums for the tagged desktop file
+and license. The `publish-extension-server` job resolves the latest stable
+M-Extension-Server release and renders
+`PKGBUILD-extension-server.template`, hashing the bundle in-flight because
+upstream publishes no checksum asset. Both then generate `.SRCINFO` with the
+current Arch `makepkg` and push only `PKGBUILD`, `.SRCINFO`, and the 0BSD
+packaging license.
 
-To inspect the rendered package locally:
+Because the server versions independently of the app, its job normally finds the
+AUR already up to date and exits without pushing.
+
+Note that `.SRCINFO` generation runs `makepkg --printsrcinfo`, which does **not**
+download sources, so CI cannot catch a wrong checksum — only users can. Both
+render scripts therefore compute checksums from the live release rather than
+accepting a hand-copied value. `pkgrel` is hardcoded to `1`; bump it in the
+template when packaging changes without a version change, or the push is a no-op.
+
+To inspect the rendered packages locally:
 
 ```sh
 scripts/render_aur_package.sh \
   v1.0.9 \
   SHA256SUMS-linux.txt \
   /tmp/mangatan-aur
+
+scripts/render_aur_extension_server.sh \
+  v1.0.6.0 \
+  /tmp/mangatan-extension-server-aur
 ```

--- a/scripts/render_aur_extension_server.sh
+++ b/scripts/render_aur_extension_server.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  printf 'Usage: %s <extension-server-release-tag> <output-directory>\n' \
+    "${0##*/}" >&2
+}
+
+if (( $# != 2 )); then
+  usage
+  exit 2
+fi
+
+release_tag=$1
+output_dir=$2
+
+# M-Extension-Server uses four-component tags such as v1.0.6.0, and publishes
+# ios-runtime-vN prereleases from the same repository. Only stable numeric tags
+# are packageable.
+if [[ ! $release_tag =~ ^v[0-9]+([.][0-9]+)*$ ]]; then
+  printf 'Expected a stable vX.Y.Z-style extension server tag, got: %s\n' \
+    "$release_tag" >&2
+  exit 1
+fi
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+template="$repo_root/packaging/arch/PKGBUILD-extension-server.template"
+package_license="$repo_root/packaging/arch/LICENSE"
+pkgver=${release_tag#v}
+server_repo="https://github.com/1Selxo/M-Extension-Server"
+
+# Upstream publishes no checksum asset for the stable bundles, so hash the
+# bundle in-flight rather than trusting a hand-copied value. This streams ~135
+# MiB and never stores it.
+checksum_url() {
+  curl --fail --location --silent --show-error "$1" |
+    sha256sum |
+    awk '{ print $1 }'
+}
+
+bundle_url="$server_repo/releases/download/$release_tag/linux-x64-bundle.zip"
+license_url="https://raw.githubusercontent.com/1Selxo/M-Extension-Server/$release_tag/LICENSE"
+bundle_checksum=$(checksum_url "$bundle_url")
+license_checksum=$(checksum_url "$license_url")
+
+for checksum in "$bundle_checksum" "$license_checksum"; do
+  if [[ ! $checksum =~ ^[[:xdigit:]]{64}$ ]]; then
+    printf 'Computed an invalid SHA-256 for %s: %s\n' \
+      "$release_tag" "$checksum" >&2
+    exit 1
+  fi
+done
+
+install -d "$output_dir"
+sed \
+  -e "s/@SERVERVER@/$pkgver/g" \
+  -e "s/@SERVER_SHA256@/$bundle_checksum/g" \
+  -e "s/@SERVER_LICENSE_SHA256@/$license_checksum/g" \
+  "$template" > "$output_dir/PKGBUILD"
+install -m644 "$package_license" "$output_dir/LICENSE"
+
+if grep -Eq '@[A-Z0-9_]+@' "$output_dir/PKGBUILD"; then
+  printf 'Rendered PKGBUILD still contains template tokens\n' >&2
+  exit 1
+fi
+
+bash -n "$output_dir/PKGBUILD"
+printf 'Rendered mangatan-extension-server %s with bundle SHA-256 %s\n' \
+  "$pkgver" "$bundle_checksum"

--- a/test/modules/more/settings/browse/extension_server_discovery_test.dart
+++ b/test/modules/more/settings/browse/extension_server_discovery_test.dart
@@ -1,0 +1,287 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/more/settings/browse/extension_server/extension_server_utils.dart';
+import 'package:mangayomi/services/m_extension_server.dart';
+import 'package:path/path.dart' as path;
+
+/// Builds the layout a distro package installs: the JAR at the root plus a
+/// `java` symlink at `jre/jre/bin/java`, the only place the app looks first.
+Future<Directory> _writeManagedInstall(
+  Directory parent, {
+  String jarName = 'MExtensionServer-v1.0.6.0.jar',
+  bool withJava = true,
+  bool withJar = true,
+}) async {
+  final root = Directory(path.join(parent.path, 'extension_server'));
+  await root.create(recursive: true);
+  if (withJar) {
+    await File(path.join(root.path, jarName)).writeAsString('jar');
+  }
+  if (withJava) {
+    final bin = Directory(path.join(root.path, 'jre', 'jre', 'bin'));
+    await bin.create(recursive: true);
+    // Mirror the package exactly: a symlink to a system JRE, not a real file.
+    // File.exists() follows links, so the preferred-path probe finds it; the
+    // recursive fallback uses followLinks: false and would not.
+    final target = File(path.join(parent.path, 'system-java'));
+    await target.writeAsString('#!/bin/sh\n');
+    await Link(path.join(bin.path, 'java')).create(target.path);
+  }
+  return root;
+}
+
+void main() {
+  group('package-managed extension server discovery', () {
+    late Directory temp;
+
+    setUp(() async {
+      temp = await Directory.systemTemp.createTemp('managed-server-');
+    });
+
+    tearDown(() async {
+      if (await temp.exists()) await temp.delete(recursive: true);
+    });
+
+    test('resolves a JAR and a symlinked java from a packaged layout', () async {
+      final root = await _writeManagedInstall(temp);
+
+      final resolved = await findSystemExtensionServer(
+        directories: [root.path],
+      );
+
+      expect(resolved, isNotNull);
+      expect(
+        resolved!.jrePath,
+        path.join(root.path, 'jre', 'jre', 'bin', 'java'),
+        reason: 'the packaged java lives at the preferred path, as a symlink',
+      );
+      expect(
+        resolved.jarPath,
+        path.join(root.path, 'MExtensionServer-v1.0.6.0.jar'),
+      );
+    }, skip: !Platform.isLinux);
+
+    test('reports the packaged version rather than the fallback', () async {
+      final root = await _writeManagedInstall(temp);
+      final resolved = await findSystemExtensionServer(
+        directories: [root.path],
+      );
+
+      expect(
+        resolveInstalledExtensionServerVersion(resolved!.jarPath),
+        '1.0.6.0',
+        reason: 'a basename without a parseable version offers a bogus update',
+      );
+    }, skip: !Platform.isLinux);
+
+    test('skips a partially removed package instead of half-adopting it', () async {
+      final noJar = await _writeManagedInstall(
+        temp,
+        withJar: false,
+      );
+      expect(
+        await findSystemExtensionServer(directories: [noJar.path]),
+        isNull,
+      );
+
+      final other = await Directory.systemTemp.createTemp('managed-nojre-');
+      addTearDown(() async {
+        if (await other.exists()) await other.delete(recursive: true);
+      });
+      final noJava = await _writeManagedInstall(other, withJava: false);
+      expect(
+        await findSystemExtensionServer(directories: [noJava.path]),
+        isNull,
+      );
+    }, skip: !Platform.isLinux);
+
+    test('falls through to a later candidate directory', () async {
+      final root = await _writeManagedInstall(temp);
+
+      final resolved = await findSystemExtensionServer(
+        directories: [path.join(temp.path, 'absent'), root.path],
+      );
+
+      expect(resolved, isNotNull);
+      expect(resolved!.jarPath, contains('MExtensionServer-'));
+    }, skip: !Platform.isLinux);
+
+    test('returns null when nothing is installed', () async {
+      expect(
+        await findSystemExtensionServer(
+          directories: [path.join(temp.path, 'absent')],
+        ),
+        isNull,
+      );
+    }, skip: !Platform.isLinux);
+  });
+
+  group('managed directory guard', () {
+    test('recognises the documented system locations', () {
+      for (final directory in extensionServerSystemDirectories) {
+        expect(isManagedExtensionServerDirectory(directory), isTrue);
+        expect(
+          isManagedExtensionServerDirectory('$directory/'),
+          isTrue,
+          reason: 'a trailing separator must not defeat the wipe guard',
+        );
+        expect(
+          isManagedExtensionServerDirectory('$directory/../extension_server'),
+          isTrue,
+          reason: 'the path is normalized before comparison',
+        );
+      }
+    });
+
+    test('leaves user-chosen directories writable', () {
+      expect(isManagedExtensionServerDirectory(''), isFalse);
+      expect(
+        isManagedExtensionServerDirectory('/home/user/Mangatan/extension_server'),
+        isFalse,
+      );
+      expect(
+        isManagedExtensionServerDirectory('/usr/share/mangatan'),
+        isFalse,
+        reason: 'only the server directory itself is package-owned',
+      );
+    });
+
+    test('the installer refuses to wipe a package-managed directory', () {
+      final screenSource = File(
+        'lib/modules/more/settings/browse/extension_server_screen.dart',
+      ).readAsStringSync().replaceAll('\r\n', '\n');
+
+      expect(
+        screenSource,
+        contains('_resolveDownloadDirectory(l10n)'),
+        reason: 'the download path must redirect away from /usr',
+      );
+      expect(
+        screenSource,
+        contains(
+          'Future<void> _prepareInstallDirectory(Directory installDir) async {\n'
+          '    // Last line of defence for the recursive delete below: callers are expected\n'
+          '    // to have gone through _resolveDownloadDirectory already.\n'
+          '    if (isManagedExtensionServerDirectory(installDir.path)) {',
+        ),
+        reason: 'delete(recursive: true) must be unreachable for /usr paths',
+      );
+    });
+  });
+
+  group('JRE version pre-flight', () {
+    test('parses the runtime the Arch package depends on', () {
+      // Verbatim from `java -version` under Arch jre21-openjdk 21.0.12.u8-1.
+      expect(
+        parseJreMajorVersion(
+          'openjdk version "21.0.12" 2026-07-21\n'
+          'OpenJDK Runtime Environment (build 21.0.12+8)\n'
+          'OpenJDK 64-Bit Server VM (build 21.0.12+8, mixed mode, sharing)',
+        ),
+        21,
+      );
+    });
+
+    test('parses a too-old runtime so the launch can be refused', () {
+      expect(
+        parseJreMajorVersion(
+          'openjdk version "17.0.19" 2026-07-15\n'
+          'OpenJDK Runtime Environment Temurin-17.0.19+7 (build 17.0.19+7)',
+        ),
+        17,
+      );
+      // The legacy scheme puts the feature version second: 1.8 means Java 8.
+      expect(
+        parseJreMajorVersion('java version "1.8.0_452"'),
+        8,
+      );
+    });
+
+    test('returns null on unparseable output so a probe never blocks', () {
+      expect(parseJreMajorVersion(''), isNull);
+      expect(parseJreMajorVersion('command not found'), isNull);
+    });
+
+    test('the service refuses to launch an unsupported runtime', () {
+      final serviceSource = File(
+        'lib/services/m_extension_server.dart',
+      ).readAsStringSync().replaceAll('\r\n', '\n');
+
+      expect(
+        serviceSource,
+        contains('static const _minimumJreMajorVersion = 21;'),
+        reason: 'the server JAR entry point is Java 21 bytecode',
+      );
+      expect(
+        serviceSource,
+        contains('final incompatibility = await _describeJreIncompatibility('),
+        reason:
+            'the plugin discards the JVM stderr, so the mismatch must be '
+            'detected before launching rather than surfacing as a timeout',
+      );
+      expect(
+        serviceSource,
+        contains('final system = await findSystemExtensionServer();'),
+        reason: 'an unconfigured desktop must adopt a distro install',
+      );
+      expect(
+        serviceSource,
+        contains('_persistResolvedServerPaths(jrePath, serverJarPath);'),
+        reason: 'the Settings screen must reflect the adopted paths',
+      );
+    });
+  });
+
+  group('Arch packaging contract', () {
+    String read(String relativePath) =>
+        File(relativePath).readAsStringSync().replaceAll('\r\n', '\n');
+
+    test('the app package pulls in the startup dependency', () {
+      final template = read('packaging/arch/PKGBUILD.template');
+
+      expect(
+        template,
+        contains("'xdg-user-dirs'"),
+        reason:
+            'path_provider_linux shells out to the xdg-user-dir binary for the '
+            'documents directory, and throws when it is absent — which also '
+            'breaks the database directory, not just the extension server',
+      );
+      expect(
+        template,
+        contains('mangatan-extension-server: '),
+        reason: 'the bridge must be discoverable but stay optional',
+      );
+    });
+
+    test('the server package installs the layout the app probes', () {
+      final template = read('packaging/arch/PKGBUILD-extension-server.template');
+
+      expect(
+        template,
+        contains(r'_jar="MExtensionServer-v${pkgver}.jar"'),
+        reason:
+            'detection requires the MExtensionServer- prefix, a .jar suffix, '
+            'and a parseable version in the basename',
+      );
+      expect(
+        template,
+        contains(r'"${pkgdir}/${_serverdir}/jre/jre/bin/java"'),
+        reason: 'findExtensionServerJavaExecutable only probes this path first',
+      );
+      expect(
+        template,
+        contains("depends=('jre21-openjdk')"),
+        reason:
+            'java-runtime>=21 can be satisfied by a newer JVM installed at a '
+            'different prefix, which would dangle the symlink above',
+      );
+      expect(
+        template,
+        contains(r'noextract=("${_bundle}")'),
+        reason: 'the vendored JRE in the bundle must never reach the package',
+      );
+    });
+  });
+}

--- a/test/modules/more/settings/browse/extension_server_discovery_test.dart
+++ b/test/modules/more/settings/browse/extension_server_discovery_test.dart
@@ -141,9 +141,37 @@ void main() {
         isFalse,
       );
       expect(
-        isManagedExtensionServerDirectory('/usr/share/mangatan'),
+        isManagedExtensionServerDirectory('/usr/share/fonts'),
         isFalse,
-        reason: 'only the server directory itself is package-owned',
+        reason: 'an unrelated /usr path is not the installer\'s business',
+      );
+    });
+
+    test('guards an ancestor of a managed directory', () {
+      // The folder picker resolves the JAR recursively, so an ancestor is a
+      // working selection — and the install would then delete(recursive: true)
+      // the whole subtree, taking the package-owned files with it.
+      for (final ancestor in [
+        '/usr/share/mangatan',
+        '/usr/share',
+        '/usr',
+        '/',
+      ]) {
+        expect(
+          isManagedExtensionServerDirectory(ancestor),
+          isTrue,
+          reason: 'wiping $ancestor would destroy a package-managed install',
+        );
+      }
+    });
+
+    test('guards a subdirectory of a managed directory', () {
+      expect(
+        isManagedExtensionServerDirectory(
+          '/usr/share/mangatan/extension_server/jre',
+        ),
+        isTrue,
+        reason: 'everything under the server directory is package-owned too',
       );
     });
 
@@ -281,6 +309,31 @@ void main() {
         template,
         contains(r'noextract=("${_bundle}")'),
         reason: 'the vendored JRE in the bundle must never reach the package',
+      );
+    });
+
+    test('the server package extracts exactly one JAR', () {
+      final template = read('packaging/arch/PKGBUILD-extension-server.template');
+
+      // `bsdtar --extract` exits 0 when a pattern matches two entries and
+      // concatenates them into one corrupt file, so the size floor below it
+      // cannot catch that case — the match count has to be checked up front.
+      expect(
+        template,
+        contains(
+          r"""matches=$(bsdtar --list --file "${_bundle}" 'MExtensionServer-*.jar' | wc -l)""",
+        ),
+        reason: 'a second matching entry would silently corrupt the JAR',
+      );
+      expect(
+        template,
+        contains('if (( matches != 1 )); then'),
+        reason: 'both zero and two matches must fail the build',
+      );
+      expect(
+        template.indexOf('matches=\$(bsdtar --list'),
+        lessThan(template.indexOf('bsdtar --extract')),
+        reason: 'the count must gate the extraction, not follow it',
       );
     });
   });


### PR DESCRIPTION
## The problem

The Mihon extension server does not work on a clean Arch Linux install, for three separate reasons. I hit this on my own machine and dug in until each one was measured rather than guessed.

### 1. The app cannot resolve its own storage directories

`StorageProvider.getDefaultDirectory()` and `getDatabaseDirectory()` both call `getApplicationDocumentsDirectory()`. On Linux `path_provider_linux` implements that as `xdg_directories.getUserDirectory('DOCUMENTS')`, which shells out to the **`xdg-user-dir` binary** and returns `null` when it is absent — at which point `path_provider` throws `MissingPlatformDirectoryException`.

That binary ships in **`xdg-user-dirs`**, which is *not* the same package as the `xdg-utils` the PKGBUILD depended on. On a minimal Arch install it simply isn't there. Since database path resolution goes through the same call, this can affect more than the extension server.

### 2. The bundled server needs Java 21, and says nothing when it doesn't get it

I range-read the real `linux-x64-bundle.zip` (v1.0.6.0, 137,155,885 bytes) and parsed the inner JAR's class files:

| Fact | Value |
|---|---|
| Bundled JRE | 21.0.12 |
| JAR | `MExtensionServer-v1.0.6.0-r1.jar`, 103,489,605 bytes |
| `mextensionserver/MainKt` class major | **65 = Java 21**, and *not* under `META-INF/versions/` |

The entry point is Java 21 bytecode outside any multi-release directory, so the JAR requires a JRE ≥ 21. My system Java was Temurin 17, which dies with `UnsupportedClassVersionError`.

The failure is invisible. The Linux plugin `dup2`s the child's stdout and stderr to `/dev/null`, so instead of an error the user gets 3 × 20 s of silent polling and one generic "did not become ready" line. Nothing points at the Java version.

### 3. A distro package could not have helped, even if one existed

`_startServer` refuses to launch unless both paths stored in settings row 227 are existing files, and always passes `jvmPath: jrePath`. There is **zero** discovery of system locations — I grepped `lib/` for `JAVA_HOME`, `/usr/bin/java` and `/usr/lib/jvm` and found no runtime hits. The Linux plugin does have a `PATH` fallback to bare `java`, but it is unreachable dead code. So a correctly installed system-wide server would still sit unused until the user walked the folder picker to it by hand.

## The fix

Three commits, smallest and most independent first.

**`fix(arch)`: add `xdg-user-dirs` to `depends`.** One line, fixes problem 1, independent of everything else here.

**`feat(extension server)`: adopt a package-managed install and pre-flight the JRE.**

- `findSystemExtensionServer()` looks under `/usr/share/mangatan/extension_server` (and `/usr/lib/...`) when the configured paths are missing, then persists what it resolves so the settings screen reflects reality. It reuses the existing `findExtensionServerJavaExecutable` / `findExtensionServerJar` helpers, and requires **both** to succeed, so a half-removed package is skipped rather than saved as a broken configuration.
- On Linux, probe `java -version` before launching. If it is older than 21, log an actionable error naming the required version instead of hanging silently. `parseJreMajorVersion` handles both the modern (`"21.0.12"` → 21) and legacy (`"1.8.0_452"` → 8) schemes.
- Refuse to install into a package-managed directory. `_prepareInstallDirectory` clears its target with `delete(recursive: true)`; once a `/usr` path can be adopted, an in-app "Update" would try to delete a pacman-owned tree. Downloads are redirected to the default directory with a toast, plus a hard guard immediately before the delete. This is the *normal* case once the bridge adopts a distro install, not an edge case.

**`feat(arch)`: publish an optional `mangatan-extension-server` package.** A separate AUR package, because the server versions independently of Mangatan and nobody should be forced to pull a ~103 MB payload; `mangatan-bin` picks it up via `optdepends`. Upstream publishes no standalone JAR asset (I checked all 10 releases via the API — only the four platform bundles), so `prepare()` extracts just the JAR with `bsdtar` and discards the vendored JRE, symlinking the system runtime into the `jre/jre/bin/java` path the app probes.

Two deliberate departures from the obvious packaging:

- **`arch=('any')`.** The JAR is byte-identical across the Linux, macOS and Windows bundles (same CRC `c8938c72`, same uncompressed size) and carries JNI natives for ~20 architectures, so it is portable as-is. Bonus: this makes the bridge available on aarch64, where the in-app download has no asset at all.
- **`depends=('jre21-openjdk')`, not `'java-runtime>=21'`.** A newer JVM satisfies that version constraint but installs under a different prefix, which would leave the symlink dangling. `jdk21-openjdk` provides `jre21-openjdk`, so both work.

Two naming constraints are load-bearing and now documented in `packaging/arch/README.md`: the JAR must keep the `MExtensionServer-` prefix and `.jar` suffix, and must retain a parseable `vX.Y.Z` in its basename or `resolveInstalledExtensionServerVersion` falls back to `1.0.0` and the app keeps offering a bogus update.

## Verification

Built and ran the real package in `archlinux:base-devel`:

- `makepkg` succeeds → `mangatan-extension-server-1.0.6.0-1-any.pkg.tar.zst`, 95,869,091 bytes.
- Payload is exactly the JAR + the symlink + the license. **Zero** vendored JRE files.
- `namcap` is clean (with the dependency installed).
- End-to-end: installed `jre21-openjdk` + the package, the symlink resolves and is executable, `java -version` → `openjdk version "21.0.12"`, ran the JAR on a port, and `curl /capabilities` returned `{"mangatanMihonBridge":1,"sourceFactory":true,"preferenceCallbacks":true,...}` — the exact triple `_supportsMangatanMihonBridge` requires.
- Both render scripts produce valid `.SRCINFO`; the live-computed bundle checksum matched the bundle actually used for the build.

Dart side:

- 14 new tests in `test/modules/more/settings/browse/extension_server_discovery_test.dart` covering discovery (against a temp tree, using a real `Link` to mirror the package exactly), the managed-directory guard, JRE version parsing (including verbatim real `java -version` output), and the two Arch packaging string contracts. All pass, as do the 4 pre-existing `m_extension_server_test.dart` tests.
- `flutter analyze` → exit 0. The 23 remaining issues are all pre-existing and none are in files this branch touches.
- Full suite: 1183 passed, 12 failed. I confirmed all 12 fail identically on a pristine `main` checkout — 7 are Isar's `libisar.so` requiring `GLIBC_2.38` (my host's glibc is older) and 5 are hoshidicts tests reading a hardcoded Windows path `D:\Japanese\Yomitan Dictionaries\...`. None are related to these changes.

Two things worth knowing for the AUR side: `pkgrel` is hardcoded to `1` in both templates, so a packaging-only change (as opposed to a version bump) needs a manual bump or the push is a no-op. And `.SRCINFO` is generated by `makepkg --printsrcinfo`, which does not download sources — a wrong checksum will not be caught in CI, only by users. That's why the render script computes both checksums from the live release rather than taking them by hand.

## Notes

`chmod +x` on the root-owned symlink (`extension_server_screen.dart`) will fail for unprivileged users, but harmlessly: `Process.run`'s exit code is ignored and the real target is already executable.

The new user-facing string is in `app_en.arb` with the generated locale files updated to the English text, matching the existing fallback pattern for the 42 keys already untranslated.

For anyone hitting this today, no packaging needed — `sudo pacman -S xdg-user-dirs jre21-openjdk && xdg-user-dirs-update`, then Settings → Browse → Extension Server → Download.
