### PR TITLE
test(mining): regression guard for issue #27 close bounding-box merge

### DIFF
--- a/test/services/mining/ocr_block_merger_test.dart
+++ b/test/services/mining/ocr_block_merger_test.dart
@@ -25,6 +25,42 @@ void main() {
 
     expect(merged.single.lines, ['right', 'left']);
   });
+
+  // Regression guard for issue #27 (merge close bounding boxes). Two separate
+  // columns whose gap is wider than the per-line same-paragraph threshold must
+  // still collapse into a single linked block/bounding box when they sit within
+  // the close-group radius, so the reader draws one box and copies one run of
+  // text instead of several disconnected fragments.
+  test('merges separate vertical columns that sit within the close radius', () {
+    final blocks = [
+      _block('AA', 0.20, 0.10, 0.23, 0.50, vertical: true),
+      _block('BB', 0.30, 0.10, 0.33, 0.50, vertical: true),
+    ];
+
+    final merged = mergeOcrBlocks(blocks, language: 'ja');
+
+    // A single merged block == a single rendered bounding box.
+    expect(merged, hasLength(1));
+    // Right-to-left Japanese reading order links both columns in one block.
+    expect(merged.single.lines, ['BB', 'AA']);
+    // The merged bounding box spans the union of both columns.
+    expect(merged.single.xmin, 0.20);
+    expect(merged.single.xmax, 0.33);
+    expect(merged.single.ymin, 0.10);
+    expect(merged.single.ymax, 0.50);
+  });
+
+  test('keeps distant boxes as separate bounding boxes', () {
+    final blocks = [
+      _block('AA', 0.10, 0.10, 0.13, 0.50, vertical: true),
+      _block('BB', 0.80, 0.10, 0.83, 0.50, vertical: true),
+    ];
+
+    final merged = mergeOcrBlocks(blocks, language: 'ja');
+
+    // Boxes far outside the close radius must not be merged.
+    expect(merged, hasLength(2));
+  });
 }
 
 OcrTextBlock _block(


### PR DESCRIPTION
## Summary

Audit of issue #27 (["[Small Improvement] Merge Close Bounding Boxes"](https://github.com/1Selxo/Mangatan/issues/27)) against the current `main` rewrite.

The issue asked for bounding boxes within a radius of each other to be merged so linked text reads more pleasantly and copies as one run. **This behavior is already implemented** by the Chimahon OCR rewrite (`d432d55e feat: align OCR and Anki mining with Chimahon`) in `lib/services/mining/ocr_block_merger.dart` — specifically the `_mergeCloseGroups` stage, which unions spatially-close paragraph groups into a single `OcrTextBlock`. Each merged block is rendered as one bounding box (`_blockRect` in `reader_ocr_overlay.dart`) and mined as one linked text run, so the reader draws and copies one box per linked passage.

However, that close-radius merge path had **no direct regression coverage** — the existing tests only exercised broken-fragment joining and vertical reading order. This PR adds the missing guard so the resolved behavior cannot silently regress. No production code changes; no `pubspec.yaml` build-number bump (test-only, not a device-testable IPA).

This is issue #27's remediation made independently reviewable — it does not close the already-closed issue.

## Changes

- `test/services/mining/ocr_block_merger_test.dart`
  - `merges separate vertical columns that sit within the close radius`: two columns whose gap exceeds the per-line same-paragraph threshold but sits inside the close-group radius collapse into **one** block with the union geometry and correct right-to-left reading order.
  - `keeps distant boxes as separate bounding boxes`: columns far outside the close radius remain separate.

## Test Plan

RED/GREEN verified via TDD by toggling `_mergeCloseGroups`:

- **RED** (merge step disabled): `merges separate vertical columns…` fails with `Expected length <1>, Actual length <2>` — proving the test genuinely guards the merge.
- **GREEN** (merge step restored, as shipped): all 4 merger tests pass; `ocr_block_merger.dart` has zero diff.

```
$ flutter test test/services/mining/ocr_block_merger_test.dart
  joins broken line fragments before paragraph grouping
  orders Japanese vertical columns from right to left
  merges separate vertical columns that sit within the close radius
  keeps distant boxes as separate bounding boxes
  All tests passed!  (+4)

$ dart format --output=none --set-exit-if-changed test/services/mining/ocr_block_merger_test.dart   # 0 changed
$ dart analyze test/services/mining/ocr_block_merger_test.dart   # No issues found!
$ git diff --check   # clean
```

Broader `flutter test test/services/mining/` → 121 passed. The only 2 failures (`animated_avif_validator_test`, `desktop_scene_capture_test`) are pre-existing on a clean checkout (missing native AVIF encoder on the Linux CI host) and unrelated to this change.

Relates to #27.
