### PR TITLE
test(mining): guard customizable OCR bounding box scaling (issue #26)

### DIFF
--- a/lib/modules/mining/widgets/reader_ocr_overlay.dart
+++ b/lib/modules/mining/widgets/reader_ocr_overlay.dart
@@ -1399,19 +1399,15 @@ class ReaderOcrController extends ChangeNotifier {
     double scaleX,
     double scaleY,
   ) {
-    final center = Offset(
-      imageRect.left + (block.xmin + block.xmax) * imageRect.width / 2,
-      imageRect.top + (block.ymin + block.ymax) * imageRect.height / 2,
+    return readerOcrScaledBlockRect(
+      xmin: block.xmin,
+      ymin: block.ymin,
+      xmax: block.xmax,
+      ymax: block.ymax,
+      imageRect: imageRect,
+      scaleX: scaleX,
+      scaleY: scaleY,
     );
-    final size = Size(
-      (block.xmax - block.xmin) * imageRect.width * scaleX,
-      (block.ymax - block.ymin) * imageRect.height * scaleY,
-    );
-    return Rect.fromCenter(
-      center: center,
-      width: size.width,
-      height: size.height,
-    ).intersect(imageRect);
   }
 
   void _paintOcrBox({
@@ -1802,6 +1798,38 @@ bool readerOcrShouldDismissRepeatedLookup({
     background: backgroundOpacity.clamp(0.0, 1.0).toDouble(),
     text: textOpacity.clamp(0.0, 1.0).toDouble(),
   );
+}
+
+/// Maps a block's normalized OCR coordinates onto [imageRect], scaling the box
+/// about its center by [scaleX]/[scaleY] before clamping it to the image.
+///
+/// Enlarging the box (scale > 1) is how the reader gives clipped OCR text more
+/// room so a larger fitted font no longer overflows the bubble (issue #26);
+/// the result is intersected with [imageRect] so an enlarged box never spills
+/// past the page edges.
+@visibleForTesting
+Rect readerOcrScaledBlockRect({
+  required double xmin,
+  required double ymin,
+  required double xmax,
+  required double ymax,
+  required Rect imageRect,
+  required double scaleX,
+  required double scaleY,
+}) {
+  final center = Offset(
+    imageRect.left + (xmin + xmax) * imageRect.width / 2,
+    imageRect.top + (ymin + ymax) * imageRect.height / 2,
+  );
+  final size = Size(
+    (xmax - xmin) * imageRect.width * scaleX,
+    (ymax - ymin) * imageRect.height * scaleY,
+  );
+  return Rect.fromCenter(
+    center: center,
+    width: size.width,
+    height: size.height,
+  ).intersect(imageRect);
 }
 
 class _OcrLineBox {

--- a/test/modules/mining/reader_ocr_overlay_geometry_test.dart
+++ b/test/modules/mining/reader_ocr_overlay_geometry_test.dart
@@ -85,6 +85,99 @@ void main() {
     expect(normalized, Rect.fromLTWH(40, 0, 320, 600));
   });
 
+  group('OCR bounding box scaling (issue #26)', () {
+    final imageRect = Rect.fromLTWH(0, 0, 400, 600);
+
+    test('unscaled box maps normalized coords straight onto the image', () {
+      final rect = readerOcrScaledBlockRect(
+        xmin: 0.25,
+        ymin: 0.5,
+        xmax: 0.75,
+        ymax: 0.75,
+        imageRect: imageRect,
+        scaleX: 1.0,
+        scaleY: 1.0,
+      );
+
+      expect(rect.left, closeTo(100, 1e-6));
+      expect(rect.top, closeTo(300, 1e-6));
+      expect(rect.width, closeTo(200, 1e-6));
+      expect(rect.height, closeTo(150, 1e-6));
+    });
+
+    test('enlarges the box about its center so bigger text fits', () {
+      final rect = readerOcrScaledBlockRect(
+        xmin: 0.25,
+        ymin: 0.5,
+        xmax: 0.75,
+        ymax: 0.75,
+        imageRect: imageRect,
+        scaleX: 1.4,
+        scaleY: 1.2,
+      );
+
+      // Center is preserved: ((0.25+0.75)/2*400, (0.5+0.75)/2*600) = (200, 375).
+      expect(rect.center.dx, closeTo(200, 1e-6));
+      expect(rect.center.dy, closeTo(375, 1e-6));
+      // Width/height grow by the respective scale factors.
+      expect(rect.width, closeTo(200 * 1.4, 1e-6));
+      expect(rect.height, closeTo(150 * 1.2, 1e-6));
+    });
+
+    test('shrinks the box symmetrically when scaled below 1', () {
+      final rect = readerOcrScaledBlockRect(
+        xmin: 0.25,
+        ymin: 0.5,
+        xmax: 0.75,
+        ymax: 0.75,
+        imageRect: imageRect,
+        scaleX: 0.8,
+        scaleY: 0.8,
+      );
+
+      expect(rect.center.dx, closeTo(200, 1e-6));
+      expect(rect.center.dy, closeTo(375, 1e-6));
+      expect(rect.width, closeTo(200 * 0.8, 1e-6));
+      expect(rect.height, closeTo(150 * 0.8, 1e-6));
+    });
+
+    test('clips an enlarged box to the image bounds', () {
+      // A box hugging the right edge, enlarged horizontally, must not spill
+      // outside the image; it is clamped by the image rect.
+      final rect = readerOcrScaledBlockRect(
+        xmin: 0.8,
+        ymin: 0.0,
+        xmax: 1.0,
+        ymax: 0.2,
+        imageRect: imageRect,
+        scaleX: 1.5,
+        scaleY: 1.5,
+      );
+
+      expect(rect.right, lessThanOrEqualTo(imageRect.right + 1e-6));
+      expect(rect.top, greaterThanOrEqualTo(imageRect.top - 1e-6));
+      expect(rect.left, greaterThanOrEqualTo(imageRect.left - 1e-6));
+    });
+
+    test('honors the image rect origin offset', () {
+      final offsetImage = Rect.fromLTWH(50, 30, 400, 600);
+      final rect = readerOcrScaledBlockRect(
+        xmin: 0.0,
+        ymin: 0.0,
+        xmax: 0.5,
+        ymax: 0.5,
+        imageRect: offsetImage,
+        scaleX: 1.0,
+        scaleY: 1.0,
+      );
+
+      expect(rect.left, closeTo(50, 1e-6));
+      expect(rect.top, closeTo(30, 1e-6));
+      expect(rect.width, closeTo(200, 1e-6));
+      expect(rect.height, closeTo(300, 1e-6));
+    });
+  });
+
   test('popup dismissal consumes the reader tap', () {
     expect(
       readerOcrShouldConsumeMissedTap(


### PR DESCRIPTION
## Summary

Issue #26 asked for the ability to customize bounding box size, because an increased font size started to clip undersized OCR bounding boxes (mainly hurting Android readability).

Audit result: the current rewrite **already resolves** this. Users can adjust the OCR bubble size via the **OCR box width** and **OCR box height** sliders in the dictionary/OCR settings (`dictionary_screen.dart`), persisted as `ocr_box_scale_x` / `ocr_box_scale_y` in `MiningPreferences` (clamped 0.8–1.5). Those scales feed the reader overlay's block-rect geometry, and the overlay auto-fits text to the box — so enlarging the box lets a larger font fit without clipping, exactly what the issue requested.

What was missing was a **regression test guarding the box-scaling geometry itself**. The overlay geometry test file covered opacities, hit-test normalization, and tap/lookup logic, but nothing pinned down how the customizable scale maps a block onto the image.

## Changes
- Extracted the box-scaling math out of the private `_ReaderOcrPainter._blockRect` into a pure `@visibleForTesting` `readerOcrScaledBlockRect(...)` helper. Behavior is byte-identical (scale width/height about the block center, then intersect the image rect); `_blockRect` now delegates to it.
- Added regression tests in `reader_ocr_overlay_geometry_test.dart`:
  - unscaled box maps normalized coords straight onto the image
  - enlarging the box (scaleX/scaleY > 1) grows it about its center so bigger text fits
  - shrinking (scale < 1) is symmetric about the center
  - an enlarged edge box is clamped to the page bounds
  - the image-rect origin offset is honored

No runtime behavior change; this is a pure refactor + tests. No pubspec build bump (not a device-testable behavior change per AGENTS.md).

## Test Plan
- `flutter test test/modules/mining/reader_ocr_overlay_geometry_test.dart` → 16 passed (5 new)
- `flutter test test/modules/mining/` → 46 passed
- `flutter test test/services/m_extension_server_test.dart` → 4 passed
- `dart format --output=none --set-exit-if-changed` on both changed files → clean
- `flutter analyze` on both changed files → No issues found
- `git diff --check` → clean

Refs #26 (issue is already closed; this PR adds guarding tests, it does not reopen or close it).