### PR TITLE
test(mining): lock editable OCR lookup text (issue #40)

### DIFF
--- a/test/modules/mining/mining_lookup_sheet_editable_test.dart
+++ b/test/modules/mining/mining_lookup_sheet_editable_test.dart
@@ -1,0 +1,97 @@
+// Regression coverage for issue #40 ("[Feature request] Editable text").
+//
+// The historical userscript could not correct OCR mistakes before a lookup.
+// The rewrite resolves this by seeding the recognized text into an editable
+// field inside [MiningLookupSheet]: the user fixes OCR errors in place, then
+// looks the corrected text up / mines it. These tests lock that capability so
+// the field cannot silently regress to read-only or drop the OCR seed.
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:mangayomi/modules/mining/widgets/mining_lookup_sheet.dart';
+import 'package:mangayomi/services/mining/mining_models.dart';
+
+void main() {
+  late Directory tempDirectory;
+
+  setUpAll(() async {
+    tempDirectory = await Directory.systemTemp.createTemp(
+      'mangatan-lookup-sheet-',
+    );
+    Hive.init(tempDirectory.path);
+  });
+
+  setUp(() async {
+    if (Hive.isBoxOpen('mining_preferences')) {
+      await Hive.box<dynamic>('mining_preferences').close();
+    }
+    await Hive.deleteBoxFromDisk('mining_preferences');
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (await tempDirectory.exists()) {
+      await tempDirectory.delete(recursive: true);
+    }
+  });
+
+  Widget host() => const MaterialApp(
+    home: Scaffold(
+      body: MiningLookupSheet(
+        initialText: '茗荷',
+        miningContext: MiningContext(mediaType: MiningMediaType.manga),
+      ),
+    ),
+  );
+
+  testWidgets('seeds the OCR text into an editable lookup field', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host());
+    await tester.pump();
+
+    final fieldFinder = find.byType(TextField);
+    expect(fieldFinder, findsOneWidget);
+
+    final field = tester.widget<TextField>(fieldFinder);
+    expect(field.controller, isNotNull);
+    expect(field.controller!.text, '茗荷');
+    // The whole point of issue #40: the OCR text must be user-correctable.
+    expect(field.enabled ?? true, isTrue);
+    expect(field.readOnly, isFalse);
+  });
+
+  testWidgets('accepts an OCR correction typed into the field', (tester) async {
+    await tester.pumpWidget(host());
+    await tester.pump();
+
+    // Simulate the user fixing an OCR error before looking the word up.
+    await tester.enterText(find.byType(TextField), '茗荷谷');
+    await tester.pump();
+
+    final field = tester.widget<TextField>(find.byType(TextField));
+    expect(field.controller!.text, '茗荷谷');
+  });
+
+  testWidgets('trims surrounding whitespace from the seeded OCR text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: MiningLookupSheet(
+            initialText: '  茗荷  ',
+            miningContext: MiningContext(mediaType: MiningMediaType.manga),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final field = tester.widget<TextField>(find.byType(TextField));
+    expect(field.controller!.text, '茗荷');
+  });
+}


### PR DESCRIPTION
## Summary

Audit of historical issue #40 — [Feature request] Editable text (https://github.com/1Selxo/Mangatan/issues/40), which asked to be able to edit OCR text when there are recognition errors. The issue was closed as *"rewriting mangatan into a proper app."*

This PR does **not** claim to close #40 (it is already closed). It relates to #40.

## Audit finding

The requested capability **already exists** in the current rewrite: when OCR text is looked up (via the reader's image-actions "lookup" flow and the dictionary screen), the recognized text is seeded into an editable `TextField` inside `MiningLookupSheet` (`lib/modules/mining/widgets/mining_lookup_sheet.dart`). The user corrects OCR mistakes in place, then looks the corrected text up / mines it. That is the "proper app" resolution of the userscript-era request.

However, this behavior had **no regression coverage**. A change making the field read-only, disabled, or dropping the OCR seed would pass CI silently.

## Change

Adds `test/modules/mining/mining_lookup_sheet_editable_test.dart` — three widget tests that lock the editable-OCR-text behavior:

1. The lookup field is seeded with the OCR text and is user-editable (not `readOnly`, not disabled).
2. A typed OCR correction is accepted by the field.
3. Surrounding whitespace on the seeded OCR text is trimmed.

Test-only change; no production code touched, so no `pubspec.yaml` build-number bump (per AGENTS.md — not device-testable).

## Verification

- Mutation check: temporarily setting `readOnly: true` on the field fails 2 of the 3 tests, proving they catch a real regression (then reverted).
- `flutter test test/modules/mining/mining_lookup_sheet_editable_test.dart` → **All tests passed** (3/3).
- `flutter test test/modules/mining/` → **All tests passed** (44/44).
- `flutter analyze test/modules/mining/mining_lookup_sheet_editable_test.dart` → **No issues found**.
- `dart format --set-exit-if-changed` → clean.
- `git diff --check` → clean.

## Test Plan
- [x] Focused tests pass
- [x] Broader mining suite green
- [x] Static analysis + formatting clean

Related to #40