### PR TITLE
fix(sources): tolerate non-numeric version components in compareVersions (refs #21)

### DIFF
--- a/lib/services/fetch_sources_list.dart
+++ b/lib/services/fetch_sources_list.dart
@@ -524,7 +524,16 @@ int compareVersions(String version1, String version2) {
   return v1Parts.length.compareTo(v2Parts.length);
 }
 
-int _parseVersionPart(String part) => part.isEmpty ? 0 : int.parse(part);
+int _parseVersionPart(String part) {
+  if (part.isEmpty) return 0;
+  // Version components can carry non-numeric suffixes (pre-release/build tags
+  // like "1727-r1234" or "0-beta") when they arrive unsanitised from external
+  // source.json (appMinVerReq / version) or server release tags. Parse the
+  // leading numeric run and ignore the rest instead of throwing
+  // FormatException, which would break source listing and the update check.
+  final match = RegExp(r'^\d+').firstMatch(part);
+  return match == null ? 0 : int.parse(match.group(0)!);
+}
 
 Future<Map<String, String>> fetchHeadersDalvik(
   InterceptedClient client,

--- a/test/services/version_comparison_test.dart
+++ b/test/services/version_comparison_test.dart
@@ -22,5 +22,21 @@ void main() {
       expect(compareVersions('1.0', '1.0.0'), lessThan(0));
       expect(compareVersions('1.0.0', '1.0.0'), 0);
     });
+
+    test('ignores a non-numeric suffix on a version component', () {
+      // Extension repos and server releases can publish pre-release / build
+      // tags such as "1.2.0-beta" or "2.0.1727-r1234". These reach
+      // compareVersions unsanitised from external source.json (appMinVerReq /
+      // version). The numeric prefix must decide the comparison instead of
+      // throwing FormatException and breaking source listing/auto-update.
+      expect(compareVersions('1.2.0-beta', '1.2.0'), 0);
+      expect(compareVersions('2.0.1727-r1234', '2.0.1728'), lessThan(0));
+      expect(compareVersions('1.3.0', '1.2.0-beta'), greaterThan(0));
+    });
+
+    test('treats a fully non-numeric component as zero', () {
+      expect(compareVersions('1.x.0', '1.0.0'), 0);
+      expect(compareVersions('1.beta', '1.0'), 0);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Audit follow-up for **issue #21 — [Request/Bug | Mobile] Update Prompt** (already closed).

The original issue is from the userscript/Suwayomi-Server era: on mobile the app ran Suwayomi-Server via Termux and the guide's `pkg install`/`wget` commands pinned an old server JAR (v2.0.1727) while the latest was v2.1.1867, so an "update available" prompt appeared. That entire mobile-server model has been **fully removed** in the current rewrite — there is no Suwayomi reference anywhere in the repo (`git log -S "Suwayomi"` is empty) and the mobile path is now the in-app "Android Proxy Server" (M-Extension-Server).

Rather than fabricate a no-op, this PR fixes a **real, still-live bug in the same version-comparison / update-prompt logic** that the issue was about.

## The bug

`compareVersions` (`lib/services/fetch_sources_list.dart`) split each dotted component and called `int.parse`, which **throws `FormatException` on any non-numeric segment**.

The app self-update path (`check_for_update.dart`) already guards against this by pre-sanitising through `_numericVersion()`. But the **extension-source update path does not** — it feeds external, untrusted `source.json` values straight in:

- `compareVersions(info.version, source.appMinVerReq!)` (source listing filter)
- `compareVersions(existingSource.version!, source.version!)` (auto-update check)

An extension publishing a version like `1.2.0-beta` or a server tag like `2.0.1727-r1234` therefore crashed source listing / the update check instead of producing a clean up-to-date / update-available result — exactly the "update prompt behaves surprisingly" family from #21.

## Fix

`_parseVersionPart` now parses the leading numeric run of each component (mirroring `_numericVersion`) and ignores any suffix, returning `0` for a fully non-numeric component, instead of throwing.

## Test Plan (TDD, RED → GREEN)

- Added regression tests in `test/services/version_comparison_test.dart`; confirmed they fail RED with `FormatException: Invalid radix-10 number` before the fix, then pass after.
- `flutter test test/services/version_comparison_test.dart` → **6 passed**
- Related suites (`m_extension_server_test.dart`, `extension_server_discovery_test.dart`, `extension_package_test.dart`) → **all pass, no regressions**
- `dart analyze` on both changed files → **No issues found**
- `dart format --set-exit-if-changed` → clean
- `git diff --check` → clean

No `pubspec.yaml` build bump: per AGENTS.md that is required only for device-testable IPAs; this is a cross-platform logic + test change.

Refs #21 (historical issue already closed — this PR does not re-close it).
