### PR TITLE
fix(ocr): order staggered Japanese bubbles right-to-left (#34)

### DIFF
--- a/lib/services/mining/ocr_block_merger.dart
+++ b/lib/services/mining/ocr_block_merger.dart
@@ -250,9 +250,22 @@ OcrTextBlock _toBlock(List<_Line> lines, String language) {
 
 List<OcrTextBlock> _readingOrder(List<OcrTextBlock> blocks, bool japanese) {
   blocks.sort((a, b) {
-    final overlap = _overlap(a.ymin, a.ymax, b.ymin, b.ymax);
-    if (overlap > 0.2) {
-      return japanese ? b.xmin.compareTo(a.xmin) : a.xmin.compareTo(b.xmin);
+    if (japanese) {
+      // Japanese manga reads right-to-left. When two blocks share a column
+      // band (they overlap horizontally) the upper one comes first; otherwise
+      // the right-hand block's sentence is read before the left-hand one,
+      // regardless of any vertical stagger between separate speech bubbles.
+      final horizontalOverlap = _overlap(a.xmin, a.xmax, b.xmin, b.xmax);
+      if (horizontalOverlap > 0.2) {
+        return a.ymin.compareTo(b.ymin);
+      }
+      return b.xmin.compareTo(a.xmin);
+    }
+    // Left-to-right scripts: blocks sharing a line band read left-to-right,
+    // otherwise top-to-bottom.
+    final verticalOverlap = _overlap(a.ymin, a.ymax, b.ymin, b.ymax);
+    if (verticalOverlap > 0.2) {
+      return a.xmin.compareTo(b.xmin);
     }
     return a.ymin.compareTo(b.ymin);
   });

--- a/test/services/mining/ocr_block_merger_test.dart
+++ b/test/services/mining/ocr_block_merger_test.dart
@@ -25,6 +25,26 @@ void main() {
 
     expect(merged.single.lines, ['right', 'left']);
   });
+
+  test('orders vertically staggered Japanese speech bubbles right to left', () {
+    // Two separate bubbles that do not vertically overlap: the left-hand
+    // bubble sits higher on the page than the right-hand one. Japanese
+    // reading order is right-to-left regardless of the vertical stagger,
+    // so the right bubble's sentence must come first. This reproduces the
+    // "order was mixed" report from issue #34.
+    final blocks = [
+      _block('leftbubble', 0.20, 0.10, 0.30, 0.35, vertical: true),
+      _block('rightbubble', 0.60, 0.40, 0.70, 0.65, vertical: true),
+    ];
+
+    final merged = mergeOcrBlocks(blocks, language: 'ja');
+
+    expect(merged, hasLength(2));
+    expect(merged.map((block) => block.text).toList(), [
+      'rightbubble',
+      'leftbubble',
+    ]);
+  });
 }
 
 OcrTextBlock _block(


### PR DESCRIPTION
## Summary

Fixes cross-box sentence ordering for Japanese OCR, addressing the "order was
mixed" symptom reported in issue #34.

The Chimahon-era `mergeOcrBlocks` "auto merge" algorithm (commit `d432d55e`)
already reconstructs OCR fragments into readable blocks and merges adjacent
boxes. However, its final reading-order pass had a gap: when two Japanese
blocks did **not** vertically overlap, the comparator fell back to a
top-to-bottom (`ymin`) ordering. Two separate speech bubbles staggered on the
page (left bubble higher than the right bubble) were therefore emitted
left-then-right instead of the correct Japanese right-to-left order, so Yomitan
saw the cross-box sentence in the wrong sequence.

## Fix

`_readingOrder` now orders blocks by their dominant separation axis:

- **Japanese:** blocks that share a column band (horizontal overlap > 0.2) read
  top-to-bottom; horizontally separated blocks read **right-to-left**,
  regardless of any vertical stagger between bubbles.
- **Left-to-right scripts:** unchanged — blocks sharing a line band read
  left-to-right, otherwise top-to-bottom.

The change is confined to `lib/services/mining/ocr_block_merger.dart` and is
cross-platform (pure Dart, no iOS/embedded-Mihon surface touched), so no
`pubspec.yaml` build-number bump is required per AGENTS.md.

## Regression test

Adds `orders vertically staggered Japanese speech bubbles right to left` in
`test/services/mining/ocr_block_merger_test.dart`, which reproduces the
reported failure (verified RED before the fix, GREEN after).

## Verification (Linux host)

```
$ flutter test test/services/mining/ocr_block_merger_test.dart
00:00 +3: All tests passed!

$ dart format --output=none --set-exit-if-changed \
    lib/services/mining/ocr_block_merger.dart \
    test/services/mining/ocr_block_merger_test.dart
Formatted 2 files (0 changed)

$ dart analyze lib/services/mining/ocr_block_merger.dart
No issues found!

$ git diff --check
(clean)
```

Broader `flutter test test/services/mining/` run: **120 passed, 2 failed**. The
two failures (`animated_avif_validator_test`, `desktop_scene_capture_test`) are
pre-existing and unrelated — they invoke `ffmpeg`, which is not installed on
this Linux CI host (`ProcessException: No such file or directory`).

Relates to #34 (historical issue, already closed; this hardens the resolution
and adds the missing regression coverage — it does not re-close the issue).
