### PR TITLE
test(repo): cover community-driven add-repo deep link (refs #37)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -93,6 +93,44 @@ Uri? initialDesktopAppLinkFromArguments(
   return null;
 }
 
+/// Community extension-repo URLs carried by a `mangayomi://add-repo` deep link.
+///
+/// This is how the community-driven source-repo feature (historical issue #37)
+/// is distributed: a shared link encodes one or more repo JSON URLs per content
+/// type, and the app subscribes to them on confirmation.
+@visibleForTesting
+class CommunityRepoUrls {
+  const CommunityRepoUrls({
+    required this.mangaUrls,
+    required this.animeUrls,
+    required this.novelUrls,
+  });
+
+  final List<String> mangaUrls;
+  final List<String> animeUrls;
+  final List<String> novelUrls;
+
+  bool get isEmpty =>
+      mangaUrls.isEmpty && animeUrls.isEmpty && novelUrls.isEmpty;
+}
+
+/// Extracts the community repo URLs from an `add-repo` app link.
+///
+/// Any other deep-link host yields an empty result so unrelated links can never
+/// smuggle repo subscriptions past the confirmation dialog.
+@visibleForTesting
+CommunityRepoUrls communityRepoUrlsFromAppLink(Uri uri) {
+  if (uri.host != 'add-repo') {
+    return const CommunityRepoUrls(mangaUrls: [], animeUrls: [], novelUrls: []);
+  }
+  final params = uri.queryParametersAll;
+  return CommunityRepoUrls(
+    mangaUrls: List<String>.from(params['manga_url'] ?? const []),
+    animeUrls: List<String>.from(params['anime_url'] ?? const []),
+    novelUrls: List<String>.from(params['novel_url'] ?? const []),
+  );
+}
+
 void main(List<String> args) async {
   // Zone-level catch-all for anything that slips through both layers
   runZonedGuarded(() async {
@@ -522,9 +560,10 @@ class _MyAppState extends ConsumerState<MyApp>
       case "add-repo":
         final repoName = uri.queryParameters["repo_name"];
         final repoUrl = uri.queryParameters["repo_url"];
-        final mangaRepoUrls = uri.queryParametersAll["manga_url"];
-        final animeRepoUrls = uri.queryParametersAll["anime_url"];
-        final novelRepoUrls = uri.queryParametersAll["novel_url"];
+        final communityRepoUrls = communityRepoUrlsFromAppLink(uri);
+        final mangaRepoUrls = communityRepoUrls.mangaUrls;
+        final animeRepoUrls = communityRepoUrls.animeUrls;
+        final novelRepoUrls = communityRepoUrls.novelUrls;
         final context = navigatorKey.currentContext;
         if (context == null || !context.mounted) return;
         final l10n = context.l10n;
@@ -553,9 +592,9 @@ class _MyAppState extends ConsumerState<MyApp>
                     if (context.mounted) Navigator.of(context).pop();
 
                     final validUrls = await _checkValidUrls([
-                      ...mangaRepoUrls ?? [],
-                      ...animeRepoUrls ?? [],
-                      ...novelRepoUrls ?? [],
+                      ...mangaRepoUrls,
+                      ...animeRepoUrls,
+                      ...novelRepoUrls,
                     ]);
 
                     if (!validUrls) {
@@ -563,8 +602,8 @@ class _MyAppState extends ConsumerState<MyApp>
                       return;
                     }
 
-                    void addRepos(ItemType type, List<String>? urls) {
-                      if (urls == null) return;
+                    void addRepos(ItemType type, List<String> urls) {
+                      if (urls.isEmpty) return;
                       final current = ref.read(
                         extensionsRepoStateProvider(type),
                       );

--- a/test/services/community_repo_deep_link_test.dart
+++ b/test/services/community_repo_deep_link_test.dart
@@ -1,0 +1,77 @@
+// Regression coverage for the community-driven extension-repo entry point.
+//
+// Historical issue #37 ("Community-driven wiki/repo for non-suwayomi sites?")
+// asked for a way to share and pull site/source configurations from a
+// community-maintained place instead of hand-editing a userscript's
+// "Site Configurations" field. In the current Mangayomi-based rewrite that
+// request is served by the extension-repository system: anyone can host a repo
+// of sources and distribute it through a `mangayomi://add-repo` deep link whose
+// `manga_url` / `anime_url` / `novel_url` query parameters carry the repo JSON
+// URLs the app then subscribes to.
+//
+// The cold-start deep-link parser (initialDesktopAppLinkFromArguments) already
+// has coverage for the host, but nothing pins the repo-URL payload that the
+// community-driven feature actually depends on. These tests lock that in so a
+// future change to argument parsing or query handling cannot silently drop the
+// community repo URLs.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/main.dart';
+
+void main() {
+  group('community-driven add-repo deep link', () {
+    test('preserves the community repo URLs for each content type', () {
+      final uri = initialDesktopAppLinkFromArguments(const [
+        'mangayomi://add-repo?repo_name=Community'
+            '&manga_url=https://example.test/manga.json'
+            '&anime_url=https://example.test/anime.json'
+            '&novel_url=https://example.test/novel.json',
+      ], platform: TargetPlatform.linux);
+
+      expect(uri, isNotNull);
+      final repoUrls = communityRepoUrlsFromAppLink(uri!);
+
+      expect(repoUrls.mangaUrls, ['https://example.test/manga.json']);
+      expect(repoUrls.animeUrls, ['https://example.test/anime.json']);
+      expect(repoUrls.novelUrls, ['https://example.test/novel.json']);
+    });
+
+    test('collects every repeated repo URL of the same content type', () {
+      final uri = Uri.parse(
+        'mangayomi://add-repo'
+        '?manga_url=https://a.test/one.json'
+        '&manga_url=https://b.test/two.json',
+      );
+
+      final repoUrls = communityRepoUrlsFromAppLink(uri);
+
+      expect(repoUrls.mangaUrls, [
+        'https://a.test/one.json',
+        'https://b.test/two.json',
+      ]);
+      expect(repoUrls.animeUrls, isEmpty);
+      expect(repoUrls.novelUrls, isEmpty);
+      expect(repoUrls.isEmpty, isFalse);
+    });
+
+    test('reports empty when no repo URLs are supplied', () {
+      final repoUrls = communityRepoUrlsFromAppLink(
+        Uri.parse('mangayomi://add-repo?repo_name=NoUrls'),
+      );
+
+      expect(repoUrls.mangaUrls, isEmpty);
+      expect(repoUrls.animeUrls, isEmpty);
+      expect(repoUrls.novelUrls, isEmpty);
+      expect(repoUrls.isEmpty, isTrue);
+    });
+
+    test('ignores repo URLs on unrelated deep-link hosts', () {
+      final repoUrls = communityRepoUrlsFromAppLink(
+        Uri.parse('mangayomi://add-button?manga_url=https://x.test/repo.json'),
+      );
+
+      expect(repoUrls.isEmpty, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Audits historical issue #37 ("Community-driven wiki/repo for non-suwayomi
sites?") against the current `main` rewrite and closes a real regression-test
gap on the feature that superseded it.

Issue #37 came from the **userscript era** of Mangatan. It described a
Tampermonkey/Greasemonkey-style "Site Configurations" field (`@match`,
`@connect`, `imageContainerSelectors`, `urlPattern`, `overflowFixSelector`) and
asked for a *community-driven place* to share and pull those site configs. None
of that userscript architecture has ever existed in this Mangayomi-based Flutter
repo (verified with `git log -S`), so there is nothing to "fix" literally.

The **intent** of the request — anyone can host a repo of source configs, users
add it, and pull updates — is already served by the current app's
extension-repository system. Community repos are distributed via
`mangayomi://add-repo` cold-start deep links whose `manga_url` / `anime_url` /
`novel_url` query parameters carry the repo JSON URLs the app subscribes to.
That is exactly what the maintainer meant when closing the issue as completed
("anyone is welcome to host a repo like that").

The honest, non-cosmetic improvement: that community-repo **payload had no
regression coverage**. The existing cold-start deep-link tests only asserted the
host (`add-repo`), never that the repo URLs survive parsing. This PR extracts a
pure, testable helper the handler now consumes and locks the behavior in.

## Changes

- `lib/main.dart`
  - Add `CommunityRepoUrls` + `communityRepoUrlsFromAppLink(Uri)` — a pure
    helper that extracts the per-content-type repo URLs from an `add-repo` deep
    link and returns empty for any other host (unrelated links can't smuggle
    repo subscriptions past the confirmation dialog).
  - Route the existing `add-repo` handler through the helper instead of reading
    `queryParametersAll` inline. No app behavior change; the URLs, validation,
    and confirmation dialog are unchanged.
- `test/services/community_repo_deep_link_test.dart` (new)
  - Repo URLs for each content type survive `add-repo` parsing.
  - Repeated URLs of the same type are all collected.
  - No URLs → reports empty.
  - Unrelated deep-link host yields no repo URLs.

## Test plan

```
flutter test test/services/community_repo_deep_link_test.dart \
             test/services/sync/google_drive_platform_support_test.dart
# 9 tests, all pass (4 new + 5 existing deep-link tests, no regression)

flutter test test/services/m_extension_server_test.dart   # AGENTS.md required: pass
dart format --output=none --set-exit-if-changed lib/main.dart \
  test/services/community_repo_deep_link_test.dart         # clean
flutter analyze lib/main.dart test/services/community_repo_deep_link_test.dart  # No issues found!
git diff --check                                            # clean
```

Dart-only test/refactor change — no native/IPA impact, so no `pubspec.yaml`
build-number bump per AGENTS.md.

Refs #37 (already closed as completed; this does not re-close it).
