### PR TITLE
test(mining): guard OCR display-settings live-apply (#24)

### DIFF
--- a/test/modules/mining/reader_ocr_display_settings_test.dart
+++ b/test/modules/mining/reader_ocr_display_settings_test.dart
@@ -1,0 +1,134 @@
+// Regression coverage for GitHub issue #24 ("Display Settings Not Respected").
+//
+// The original userscript/Mokuro-era reader required an explicit
+// "save and reload" step before OCR display settings took effect, which led
+// users to believe adjusting a slider did nothing. The current Flutter reader
+// exposes the OCR appearance settings as live [ValueNotifier]s that every
+// attached [ReaderOcrController] listens to, so a change repaints the overlay
+// immediately with no save/reload button, and also persists so the setting
+// survives a reload.
+//
+// These tests pin that live-apply contract: mutating a display setting must
+// (a) update the shared notifier value, (b) notify attached controllers so the
+// overlay repaints, and (c) persist so a subsequent read observes the value.
+// If a future refactor drops any of that wiring, issue #24 regresses and these
+// tests fail.
+
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:mangayomi/modules/manga/reader/u_chap_data_preload.dart';
+import 'package:mangayomi/modules/mining/widgets/reader_ocr_overlay.dart';
+import 'package:mangayomi/services/mining/mining_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDirectory;
+
+  setUpAll(() async {
+    tempDirectory = await Directory.systemTemp.createTemp(
+      'mangatan-ocr-display-settings-',
+    );
+    Hive.init(tempDirectory.path);
+  });
+
+  setUp(() async {
+    if (Hive.isBoxOpen('mining_preferences')) {
+      await Hive.box<dynamic>('mining_preferences').close();
+    }
+    await Hive.deleteBoxFromDisk('mining_preferences');
+
+    // Restore the shared appearance state to its packaged defaults so each
+    // test observes a real transition rather than a stale value.
+    ReaderOcrState.backgroundOpacity.value =
+        MiningPreferences.defaultOcrBackgroundOpacity;
+    ReaderOcrState.textOpacity.value = MiningPreferences.defaultOcrTextOpacity;
+    ReaderOcrState.outlineVisible.value = false;
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (await tempDirectory.exists()) {
+      await tempDirectory.delete(recursive: true);
+    }
+  });
+
+  test('setBackgroundOpacity applies live and persists', () async {
+    final observed = <double>[];
+    void listener() => observed.add(ReaderOcrState.backgroundOpacity.value);
+    ReaderOcrState.backgroundOpacity.addListener(listener);
+    addTearDown(
+      () => ReaderOcrState.backgroundOpacity.removeListener(listener),
+    );
+
+    await ReaderOcrState.setBackgroundOpacity(0.2);
+
+    expect(ReaderOcrState.backgroundOpacity.value, 0.2);
+    expect(observed, contains(0.2));
+    // A reload reads back the persisted value, not the packaged default.
+    expect(await MiningPreferences.getOcrBackgroundOpacity(), 0.2);
+  });
+
+  test('setTextOpacity applies live and persists', () async {
+    final observed = <double>[];
+    void listener() => observed.add(ReaderOcrState.textOpacity.value);
+    ReaderOcrState.textOpacity.addListener(listener);
+    addTearDown(() => ReaderOcrState.textOpacity.removeListener(listener));
+
+    await ReaderOcrState.setTextOpacity(0.35);
+
+    expect(ReaderOcrState.textOpacity.value, 0.35);
+    expect(observed, contains(0.35));
+    expect(await MiningPreferences.getOcrTextOpacity(), 0.35);
+  });
+
+  test('setOutlineVisible applies live and persists', () async {
+    final observed = <bool>[];
+    void listener() => observed.add(ReaderOcrState.outlineVisible.value);
+    ReaderOcrState.outlineVisible.addListener(listener);
+    addTearDown(() => ReaderOcrState.outlineVisible.removeListener(listener));
+
+    await ReaderOcrState.setOutlineVisible(true);
+
+    expect(ReaderOcrState.outlineVisible.value, isTrue);
+    expect(observed, contains(true));
+    expect(await MiningPreferences.getOcrOutlineVisible(), isTrue);
+  });
+
+  test(
+    'display-setting changes repaint attached controllers without a reload',
+    () async {
+      // A transition page short-circuits load(), so no Isar image lookup is
+      // needed to exercise the appearance listener wiring.
+      final data = UChapDataPreload(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        isTransitionPage: true,
+      );
+      final controller = ReaderOcrController(data, imageKey: GlobalKey());
+      addTearDown(controller.dispose);
+
+      var repaints = 0;
+      void onRepaint() => repaints++;
+      controller.addListener(onRepaint);
+      addTearDown(() => controller.removeListener(onRepaint));
+
+      await ReaderOcrState.setBackgroundOpacity(0.15);
+      await ReaderOcrState.setTextOpacity(0.5);
+      await ReaderOcrState.setOutlineVisible(true);
+
+      // Each of the three appearance changes must have driven a repaint of the
+      // overlay controller; issue #24 was the absence of exactly this signal.
+      expect(repaints, greaterThanOrEqualTo(3));
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Audit of historical issue #24 ("Display Settings Not Respected") against the
current `main` rewrite. The issue was reported and closed on 2025-08-15: the
reporter (@SpazzTL) found adjusting OCR display settings had no effect, then
self-resolved it — they had not seen the userscript/Mokuro-era **"save and
reload"** button that was required before settings took effect.

The current Flutter reader has a fundamentally different architecture: OCR
appearance settings (`backgroundOpacity`, `textOpacity`, `outlineVisible`) are
live `ValueNotifier`s on `ReaderOcrState`. Every attached `ReaderOcrController`
subscribes via `_appearanceChanged` and calls `notifyListeners()` on change, so
the overlay repaints **immediately** — there is no save/reload step to miss.
The user-facing cause of #24 cannot recur here.

However, that live-apply wiring had **no regression test**. The existing
`reader_ocr_overlay_geometry_test.dart` covers only the pure opacity-selection
function (`readerOcrContentOpacities`), not the setter → notify → repaint chain
that is the actual mechanism preventing #24 from recurring. This PR adds that
missing coverage. No production code changes — the behavior is already correct.

## Changes

- Add `test/modules/mining/reader_ocr_display_settings_test.dart`:
  - `setBackgroundOpacity` / `setTextOpacity` / `setOutlineVisible` update the
    shared notifier value, notify listeners, **and persist** so a reload reads
    the new value back (proving no save/reload button is needed).
  - An attached `ReaderOcrController` repaints (`notifyListeners`) on each of
    the three appearance changes — the exact signal whose absence #24 described.

## Test plan / verification

RED proof (the test genuinely guards the fix, not a no-op): temporarily
removing the controller's appearance-listener registration in
`ReaderOcrController` drops the observed repaint count to `0`, failing
`display-setting changes repaint attached controllers without a reload`.
Restoring the wiring makes it green. Production code is unchanged in this PR.

```
$ flutter test test/modules/mining/reader_ocr_display_settings_test.dart
  +4: All tests passed!

$ flutter test test/modules/mining/          # broader mining module
  +45: All tests passed!

$ dart format --output=none --set-exit-if-changed \
    test/modules/mining/reader_ocr_display_settings_test.dart
  Formatted 1 file (0 changed)

$ flutter analyze test/modules/mining/reader_ocr_display_settings_test.dart
  No issues found!

$ git diff --check
  (clean)
```

Per AGENTS.md, no `pubspec.yaml` build-number bump: this is a test-only change
and not a device-testable IPA change.

Relates to #24 (already closed as completed; this PR does not re-close it).
