### PR TITLE
test(anki): lock AnkiConnect media upload to base64 data (refs #42)

### DIFF
--- a/lib/services/mining/anki_connect_service.dart
+++ b/lib/services/mining/anki_connect_service.dart
@@ -148,6 +148,15 @@ class AnkiConnectService {
     return (result as List).map((item) => item as int).toList();
   }
 
+  /// Uploads media by embedding the raw bytes as base64 `data`.
+  ///
+  /// Regression guard for issue #42 ("Screenshot | Anki image export
+  /// Failure"): never switch this to AnkiConnect's `url`/`path` fetch modes.
+  /// When Suwayomi/OCR is self-hosted behind a Cloudflare Zero Trust (or any
+  /// authenticated) custom domain, a non-host device cannot make the
+  /// AnkiConnect server fetch the image itself — the server hits the auth wall
+  /// and Anki reports "Failure to load image". Embedding `data` keeps the image
+  /// inside the request so export works regardless of where the server runs.
   Future<String?> storeMediaFile({
     required String filename,
     required Uint8List data,

--- a/test/services/mining/anki_connect_service_test.dart
+++ b/test/services/mining/anki_connect_service_test.dart
@@ -519,4 +519,85 @@ void main() {
 
     expect(cards, [101, 102]);
   });
+
+  // Regression for issue #42: "Screenshot | Anki image export Failure".
+  //
+  // When Suwayomi/OCR is self-hosted behind a Cloudflare Zero Trust custom
+  // domain, non-host devices cannot let the AnkiConnect server *fetch* an image
+  // by URL: the fetch hits the auth wall and AnkiConnect reports "Failure to
+  // load image". storeMediaFile MUST embed the raw bytes as base64 `data` so
+  // the image travels inside the request and never depends on the server
+  // reaching back out over the network. It must never send a `url` (or `path`)
+  // that would delegate the download to AnkiConnect.
+  test('storeMediaFile embeds bytes as base64 data, never a url', () async {
+    final bytes = Uint8List.fromList([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+    Map<String, dynamic>? storeParams;
+    final client = MockClient((request) async {
+      final body = jsonDecode(request.body) as Map<String, dynamic>;
+      expect(body['action'], 'storeMediaFile');
+      storeParams = body['params'] as Map<String, dynamic>;
+      return http.Response('{"result": "shot.png", "error": null}', 200);
+    });
+
+    final stored = await AnkiConnectService(
+      client: client,
+    ).storeMediaFile(filename: 'shot.png', data: bytes);
+
+    expect(stored, 'shot.png');
+    expect(storeParams, isNotNull);
+    expect(storeParams!['filename'], 'shot.png');
+    expect(storeParams!['data'], base64Encode(bytes));
+    // The URL/path fetch modes are exactly what broke behind Cloudflare Zero
+    // Trust; they must never be used for locally captured screenshots.
+    expect(storeParams!.containsKey('url'), isFalse);
+    expect(storeParams!.containsKey('path'), isFalse);
+  });
+
+  test(
+    'exports a screenshot as base64 data so a remote host is never fetched',
+    () async {
+      final screenshotBytes = Uint8List.fromList([1, 2, 3, 4, 5]);
+      final storeRequests = <Map<String, dynamic>>[];
+      final client = MockClient((request) async {
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        switch (body['action']) {
+          case 'modelFieldNames':
+            return http.Response(
+              '{"result": ["Front", "Back"], "error": null}',
+              200,
+            );
+          case 'canAddNotesWithErrorDetail':
+            return http.Response(
+              '{"result": [{"canAdd": true, "error": null}], "error": null}',
+              200,
+            );
+          case 'storeMediaFile':
+            storeRequests.add(body['params'] as Map<String, dynamic>);
+            return http.Response('{"result": "shot.png", "error": null}', 200);
+          case 'addNote':
+            return http.Response('{"result": 99, "error": null}', 200);
+        }
+        fail('Unexpected action: ${body['action']}');
+      });
+
+      final noteId = await AnkiConnectService(client: client).exportDraft(
+        AnkiCardDraft(
+          deckName: 'Mining',
+          modelName: 'Basic',
+          expression: '猫',
+          fields: const {'Front': '猫', 'Back': '<img src="shot.png">'},
+          screenshotFileName: 'shot.png',
+          screenshotBytes: screenshotBytes,
+        ),
+      );
+
+      expect(noteId, 99);
+      expect(storeRequests, hasLength(1));
+      final params = storeRequests.single;
+      expect(params['filename'], 'shot.png');
+      expect(params['data'], base64Encode(screenshotBytes));
+      expect(params.containsKey('url'), isFalse);
+      expect(params.containsKey('path'), isFalse);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Audits historical issue #42 ("Screenshot | Anki image export Failure") against the current rewrite and locks in the fix with regression coverage.

**Reported behaviour (#42):** When Suwayomi/OCR is self-hosted behind a Cloudflare Zero Trust custom domain, screenshot/image export to Anki failed with "Failure to load image" on every device except the host. The discussion narrowed the cause to the userscript-era approach of handing the image to AnkiConnect by **URL** — a non-host device cannot make the AnkiConnect server fetch that URL through the Zero Trust auth wall (base64 was flagged as the fix to investigate).

**Current state:** The rewrite already resolves this. `AnkiConnectService.storeMediaFile` uploads media by embedding the raw bytes as base64 `data`, so the image travels inside the request and never depends on the server reaching back out over the network — it works regardless of where the server is hosted. The gap was that **no test pinned this behaviour**, so a future "optimisation" back to a `url`/`path` fetch could silently reintroduce the #42 failure.

## What this PR does

- Adds two regression tests to `anki_connect_service_test.dart`:
  - `storeMediaFile embeds bytes as base64 data, never a url` — asserts `data == base64(bytes)` and that neither `url` nor `path` is sent.
  - `exports a screenshot as base64 data so a remote host is never fetched` — drives the full `exportDraft` screenshot path and asserts the same.
- Documents the constraint directly on `storeMediaFile` so it is not re-introduced.

No runtime behaviour change (the implementation is byte-identical to before this PR); this is characterization + guard coverage.

## Verification

- Confirmed the new tests genuinely catch the regression: reverting `storeMediaFile` to a URL fetch makes both new tests fail (`Expected: '<base64>' / Actual: <null>`) while the 12 pre-existing tests stay green. Restored, all 14 pass.
- `flutter test test/services/mining/anki_connect_service_test.dart` → `+14: All tests passed!`
- `dart format --output=none --set-exit-if-changed` on both touched files → clean.
- `flutter analyze` on both touched files → `No issues found!`
- `git diff --check` → clean.

Two AVIF tests elsewhere in `test/services/mining/` (`animated_avif_validator_test.dart`, `desktop_scene_capture_test.dart`) fail on this Linux CI host due to a missing native AVIF/FFI toolchain; verified they fail identically on a clean checkout without this change, so they are pre-existing and unrelated.

The `pubspec.yaml` build number is intentionally not bumped: per AGENTS.md it is bumped only for device-testable IPA changes, and this is a test/documentation-only change with no runtime effect.

Refs #42 (historical issue already closed as part of the rewrite; this PR does not claim to close it).
