### PR TITLE
test(anki): lock issue #36 scalable-screenshot crop invariants

### DIFF
--- a/test/services/mining/anki_card_builder_test.dart
+++ b/test/services/mining/anki_card_builder_test.dart
@@ -657,6 +657,94 @@ void main() {
     expect(loads, 0);
     expect(draft.fields['DefinitionPicture'], isEmpty);
   });
+
+  // Issue #36 ("Scalable screenshot"): manga mining can crop the page down to
+  // a single panel of user-chosen dimensions before export. The crop happens
+  // in the popup by overriding MiningContext.imageBytesLoader so it returns the
+  // manually cropped bytes. These regressions lock the builder's contract that
+  // makes that feature work: it must ship the exact cropped bytes it is given,
+  // and a cancelled crop must abort the whole export rather than falling back
+  // to the full page.
+  test('crop mode embeds the exact manually cropped panel bytes', () async {
+    // A small single-panel PNG the compressor cannot shrink further, so the
+    // builder must keep the cropped bytes verbatim.
+    final panel = image.Image(width: 24, height: 24);
+    for (var y = 0; y < panel.height; y++) {
+      for (var x = 0; x < panel.width; x++) {
+        panel.setPixelRgb(x, y, 10, 20, 30);
+      }
+    }
+    final croppedPng = Uint8List.fromList(image.encodePng(panel));
+
+    final draft = await const AnkiCardBuilder().build(
+      result: _simpleResult(),
+      context: MiningContext(
+        sentence: '事件が起きた。',
+        mediaType: MiningMediaType.manga,
+        // The popup's crop dialog resolves to these cropped bytes.
+        imageBytesLoader: () async => croppedPng,
+      ),
+      profile: const AnkiMiningProfile(
+        fieldMap: {'Picture': AnkiMarker.screenshot},
+      ),
+      screenshotMode: AnkiScreenshotMode.crop,
+    );
+
+    expect(draft.screenshotFileName, endsWith('.png'));
+    expect(draft.screenshotBytes, isNotNull);
+    expect(draft.screenshotBytes, orderedEquals(croppedPng));
+    expect(draft.fields['Picture'], contains('<img src="'));
+  });
+
+  test(
+    'cancelling the crop dialog aborts the export instead of using the full page',
+    () async {
+      // A cancelled crop surfaces as AnkiExportCancelledException from the
+      // overridden loader; the builder must propagate it, never silently
+      // exporting the uncropped page.
+      expect(
+        () => const AnkiCardBuilder().build(
+          result: _simpleResult(),
+          context: MiningContext(
+            mediaType: MiningMediaType.manga,
+            imageBytesLoader: () async =>
+                throw const AnkiExportCancelledException(),
+          ),
+          profile: const AnkiMiningProfile(
+            fieldMap: {'Picture': AnkiMarker.screenshot},
+          ),
+          screenshotMode: AnkiScreenshotMode.crop,
+        ),
+        throwsA(isA<AnkiExportCancelledException>()),
+      );
+    },
+  );
+
+  test(
+    'cancelling the crop during pending preparation aborts the export',
+    () async {
+      final pending = await const AnkiCardBuilder().buildPending(
+        result: _simpleResult(),
+        context: MiningContext(
+          mediaType: MiningMediaType.manga,
+          imageBytesLoader: () async =>
+              throw const AnkiExportCancelledException(),
+        ),
+        profile: const AnkiMiningProfile(
+          fieldMap: {'Picture': AnkiMarker.screenshot},
+        ),
+        screenshotMode: AnkiScreenshotMode.crop,
+      );
+
+      // The placeholder is built without the screenshot, so it is safe.
+      expect(pending.placeholderDraft.fields['Picture'], isEmpty);
+      // Preparation runs the crop loader, which cancels.
+      await expectLater(
+        pending.prepare(null),
+        throwsA(isA<AnkiExportCancelledException>()),
+      );
+    },
+  );
 }
 
 HoshiLookupResult _simpleResult() => const HoshiLookupResult(


### PR DESCRIPTION
## Summary

Issue #36 ("[Feature request] Scalable screenshot", Refs #36) asked for the ability to screenshot a **single manga panel with adjustable dimensions** instead of the whole page. The maintainer confirmed it ("added", 2025-10-17) and it should stay manual, not automatic.

That feature is implemented today as `AnkiScreenshotMode.crop`: when mining a manga page, `_showCropDialog` in `hoshi_dictionary_popup.dart` lets the user free-crop the page, and the export overrides `MiningContext.imageBytesLoader` so the manually cropped bytes are what flow into the Anki card. The crop-mode wire value, migration, and enum round-trip already have coverage, but the **builder contract that actually makes the cropped panel land in Anki was untested**.

This PR is audit-driven and **adds regression tests only** — no production code changes — locking three invariants that the crop feature silently depends on:

1. **`crop mode embeds the exact manually cropped panel bytes`** — a small single-panel PNG returned by the (crop-overridden) loader is shipped verbatim; the compressor must not mutate it and the full page must never be substituted.
2. **`cancelling the crop dialog aborts the export instead of using the full page`** — a dismissed crop surfaces as `AnkiExportCancelledException` from the loader, which `AnkiCardBuilder.build()` must propagate rather than silently exporting the uncropped page.
3. **`cancelling the crop during pending preparation aborts the export`** — same guarantee on the `buildPending().prepare()` path used by AnkiConnect.

## Why tests, not code
Per the audit mission: the historical issue is resolved in the current rewrite (crop screenshot dialog added in commit `c8f1cb2b`, enum in `8f569f6e`). A production "fix" would be a no-op/cosmetic change and dishonest. The honest, non-cosmetic improvement is regression coverage that prevents the manual-crop behavior from silently regressing (e.g. someone re-adding a full-page fallback, or the compressor clobbering the crop).

## Verification (this Linux host)

RED→GREEN falsification (temporarily swallowing the cancellation and appending a byte in `AnkiCardBuilder._loadScreenshot`):
```
+13 -1: crop mode embeds the exact manually cropped panel bytes [E]
        Expected: equals [...]  Actual: [...]   (byte-mangling caught)
+13 -2: cancelling the crop dialog aborts the export ... [E]
        Expected: throws <AnkiExportCancelledException>
+13 -3: cancelling the crop during pending preparation aborts the export [E]
        Expected: throws <AnkiExportCancelledException>
```
Production code restored (empty diff) → GREEN:
```
flutter test test/services/mining/anki_card_builder_test.dart
  00:01 +16: All tests passed!

dart format --output=none --set-exit-if-changed test/services/mining/anki_card_builder_test.dart
  Formatted 1 file (0 changed)

git diff --cached --check   # clean
```
Broader `flutter test test/services/mining/` = 122 passed; the only 2 failures (`animated_avif_validator_test`, `desktop_scene_capture_test`) are pre-existing, unrelated AVIF-encoding tests that require native tooling absent on this Linux host.

No `pubspec.yaml` build-number bump: this is a test-only change with no device-testable artifact (AGENTS.md requires the bump only for device-testable IPAs).

Does not close #36 (already closed/completed); this hardens the shipped behavior.