### PR TITLE
fix(reader): stop shrinking merged OCR text in large panels (#39)

### DIFF
--- a/lib/modules/mining/widgets/reader_ocr_overlay.dart
+++ b/lib/modules/mining/widgets/reader_ocr_overlay.dart
@@ -1478,8 +1478,10 @@ class ReaderOcrController extends ChangeNotifier {
     String text,
     double alpha,
   ) {
+    // Wrap the text to the box width instead of forcing a single line. A wide
+    // or merged panel (issue #39) then keeps a readable font by wrapping rather
+    // than shrinking the whole line to fit the box's aspect ratio.
     final painter = TextPainter(
-      maxLines: 1,
       text: TextSpan(
         text: text,
         style: TextStyle(
@@ -1490,10 +1492,10 @@ class ReaderOcrController extends ChangeNotifier {
       ),
       textDirection: TextDirection.ltr,
       textAlign: TextAlign.center,
-    )..layout();
-    final scale = math.min(
-      rect.width / math.max(1, painter.width),
-      rect.height / math.max(1, painter.height),
+    )..layout(maxWidth: math.max(1, rect.width));
+    final scale = readerOcrHorizontalTextScale(
+      rect: rect.size,
+      wrappedTextSize: Size(painter.width, painter.height),
     );
     canvas.save();
     canvas.clipRect(rect);
@@ -1790,6 +1792,27 @@ bool readerOcrShouldDismissRepeatedLookup({
   required int hitOffset,
 }) =>
     popupVisible && !triggeredByHover && sameBlock && activeOffset == hitOffset;
+
+/// Chooses the paint scale for wrapped horizontal OCR text.
+///
+/// Regression guard for issue #39 ("Merged text becomes too small"). The text
+/// is laid out wrapped to the box width by the caller, so a wide/large panel no
+/// longer forces a single long line. This helper therefore only ever shrinks
+/// the wrapped block when it still overflows the box, and never enlarges past
+/// its natural size. Text that already fits renders at scale 1.0 instead of
+/// being blown up or collapsed to fit the box's aspect ratio.
+@visibleForTesting
+double readerOcrHorizontalTextScale({
+  required Size rect,
+  required Size wrappedTextSize,
+}) {
+  final scale = math.min(
+    rect.width / math.max(1, wrappedTextSize.width),
+    rect.height / math.max(1, wrappedTextSize.height),
+  );
+  if (scale.isNaN || scale <= 0) return 1.0;
+  return math.min(1.0, scale);
+}
 
 @visibleForTesting
 ({double background, double text}) readerOcrContentOpacities({

--- a/test/modules/mining/reader_ocr_text_scale_test.dart
+++ b/test/modules/mining/reader_ocr_text_scale_test.dart
@@ -1,0 +1,66 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/mining/widgets/reader_ocr_overlay.dart';
+
+void main() {
+  // Regression for issue #39: "Merged text becomes too small".
+  //
+  // When a merged/large OCR box is wide relative to the single-line text it
+  // holds, the old renderer laid the text out on ONE line and scaled it by
+  // `min(rect.width / width, rect.height / height)`. A short line inside a big
+  // panel therefore collapsed to a tiny font even though the box had ample
+  // room. The reporter asked to "let the box wrap the text without shrinking
+  // it". The helper must never shrink text that already fits the box, and must
+  // prefer wrapping over shrinking.
+
+  group('readerOcrHorizontalTextScale', () {
+    test('does not shrink text that already fits the box', () {
+      // Wrapped text comfortably fits inside a large panel.
+      final scale = readerOcrHorizontalTextScale(
+        rect: const Size(400, 300),
+        wrappedTextSize: const Size(200, 60),
+      );
+      expect(scale, 1.0);
+    });
+
+    test('keeps full size when a wide panel wraps a short line', () {
+      // The classic issue #39 case: box is far wider/taller than the text
+      // needs after wrapping. The old min-scale logic would have blown the
+      // text up or (for the single-line variant) shrunk it. Wrapped text that
+      // fits must render at the natural size, never scaled down.
+      final scale = readerOcrHorizontalTextScale(
+        rect: const Size(780, 305),
+        wrappedTextSize: const Size(300, 44),
+      );
+      expect(scale, 1.0);
+    });
+
+    test('shrinks only enough to fit when wrapped text overflows height', () {
+      // Even after wrapping, the text is taller than the box, so it must be
+      // scaled down by the limiting (height) ratio — and only that far.
+      final scale = readerOcrHorizontalTextScale(
+        rect: const Size(200, 100),
+        wrappedTextSize: const Size(180, 200),
+      );
+      expect(scale, closeTo(0.5, 1e-9));
+    });
+
+    test('shrinks by width when wrapped text still overflows horizontally', () {
+      // A single long unbreakable token can overflow width even after wrap.
+      final scale = readerOcrHorizontalTextScale(
+        rect: const Size(100, 400),
+        wrappedTextSize: const Size(250, 40),
+      );
+      expect(scale, closeTo(0.4, 1e-9));
+    });
+
+    test('never returns a non-positive scale for degenerate boxes', () {
+      final scale = readerOcrHorizontalTextScale(
+        rect: const Size(0, 0),
+        wrappedTextSize: const Size(120, 40),
+      );
+      expect(scale, greaterThan(0));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the "merged text becomes too small" behaviour reported in #39.

Horizontal OCR text in the reader overlay (`reader_ocr_overlay.dart`) was laid
out on a **single line** (`maxLines: 1`) and then scaled by
`min(rect.width / width, rect.height / height)`. Whenever a box was wide or
tall relative to the single-line text it held — exactly what happens with the
large/merged panels in the issue screenshots — the box's aspect ratio dragged
the whole line down to an unreadably small font.

This change makes the renderer **wrap** the text to the box width and only
shrink it when the wrapped block still overflows the box, never below its
natural size. That matches the reporter's request to "let the box wrap the text
without shrinking it".

## Changes

- `lib/modules/mining/widgets/reader_ocr_overlay.dart`
  - `_paintHorizontalText` now lays text out wrapped to `rect.width` instead of
    a single line.
  - The scale decision is extracted into a pure, testable
    `readerOcrHorizontalTextScale` helper (same top-level `@visibleForTesting`
    pattern as the existing geometry/opacity helpers).
- `test/modules/mining/reader_ocr_text_scale_test.dart` (new)
  - Regression tests: text that fits is never shrunk (scale `1.0`), a wide
    panel wrapping a short line stays full size, and overflow is scaled down by
    exactly the limiting dimension.

## Test plan

- [x] `flutter test test/modules/mining/reader_ocr_text_scale_test.dart` — 5/5 pass
- [x] `flutter test test/modules/mining/ test/services/mining/` — 164 pass; the
      only 2 failures are pre-existing and environmental (`ffmpeg` not installed
      on the Linux CI host, `animated_avif_validator`/`desktop_scene_capture`),
      identical with or without this change.
- [x] `flutter analyze` on the touched files — No issues found
- [x] `dart format --set-exit-if-changed` — clean
- [x] `git diff --check` — clean

No `pubspec.yaml` build-number bump: this is a source-only change producing no
IPA artifact, and the repo bumps the build number at release-prep time, not per
fix commit.

Refs #39 (issue already closed; this PR hardens the reader-overlay rewrite
against a recurrence and adds the missing regression coverage).
