### PR TITLE
test(mining): lock bulk-cache dedupe for Mokuro OCR sidecars (#47)

### DIFF
--- a/lib/services/mining/mokuro_sidecar.dart
+++ b/lib/services/mining/mokuro_sidecar.dart
@@ -7,6 +7,16 @@ import 'package:mangayomi/services/mining/mokuro_parser.dart';
 import 'package:mangayomi/services/mining/mokuro_sidecar_path.dart';
 import 'package:path/path.dart' as p;
 
+/// Persists the pre-generated Mokuro OCR sidecar next to a downloaded chapter.
+///
+/// This is what makes bulk caching (issue #47) safe: downloading chapters in
+/// bulk fetches only the pre-generated `.mokuro` OCR published by the Mokuro
+/// extension, never the live Google Lens endpoint, so a "download all" cannot
+/// abuse that API. Because the download queue constructs a fresh store per
+/// chapter, the in-flight write map is [static]: concurrent downloads that
+/// target the same sidecar collapse to one write, and the underlying
+/// [MokuroExtensionOcrClient] volume cache collapses many chapters of one
+/// volume to a single network fetch.
 class MokuroSidecarStore {
   MokuroSidecarStore({http.Client? client})
     : _client = MokuroExtensionOcrClient(client: client);

--- a/test/services/mining/mokuro_sidecar_test.dart
+++ b/test/services/mining/mokuro_sidecar_test.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -132,6 +134,57 @@ void main() {
     store.close();
   });
 
+  test(
+    'bulk downloads dedupe one volume to a single fetch across stores',
+    () async {
+      // Bulk caching (issue #47) creates a fresh MokuroSidecarStore per
+      // queued chapter. When several of those chapters resolve to the same
+      // Mokuro volume and race before any sidecar is on disk, the shared
+      // in-memory volume cache must collapse them to a single network fetch
+      // so a bulk "download all" cannot hammer the Mokuro server.
+      var requests = 0;
+      final completer = Completer<void>();
+      http.Client makeClient() => MockClient((_) async {
+        requests++;
+        await completer.future;
+        return _volumeResponse();
+      });
+
+      final artifacts = List.generate(
+        5,
+        (index) => File(p.join(temporaryDirectory.path, 'Volume $index.cbz')),
+      );
+      for (final artifact in artifacts) {
+        await artifact.writeAsBytes(const [1]);
+      }
+
+      final stores = [
+        for (var i = 0; i < artifacts.length; i++)
+          MokuroSidecarStore(client: makeClient()),
+      ];
+      final pending = [
+        for (var i = 0; i < artifacts.length; i++)
+          stores[i].ensureDownloaded(
+            sourceName: 'Mokuro',
+            chapterUrl: 'series|volume',
+            artifact: artifacts[i],
+          ),
+      ];
+
+      completer.complete();
+      final results = await Future.wait(pending);
+
+      expect(results, everyElement(isTrue));
+      expect(requests, 1);
+      for (final artifact in artifacts) {
+        expect(await mokuroSidecarFor(artifact).readAsBytes(), _volumeBytes);
+      }
+      for (final store in stores) {
+        store.close();
+      }
+    },
+  );
+
   test('does nothing for chapters outside the Mokuro extension', () async {
     var requests = 0;
     final store = MokuroSidecarStore(
@@ -165,7 +218,11 @@ const _volumeJson = {
 };
 
 http.Response _volumeResponse() => http.Response.bytes(
-  utf8.encode(jsonEncode(_volumeJson)),
+  _volumeBytes,
   200,
   headers: const {'content-type': 'application/octet-stream'},
+);
+
+final Uint8List _volumeBytes = Uint8List.fromList(
+  utf8.encode(jsonEncode(_volumeJson)),
 );


### PR DESCRIPTION
## Summary

Audit and hardening of historical issue #47 ("Bulk Caching") against the current rewrite.

Issue #47 (https://github.com/1Selxo/Mangatan/issues/47) asked for the ability to **bulk cache all downloaded/selected chapters**, explicitly limited to local/pre-generated OCR because the author feared "getting glens [Google Lens] api banned" from bulk OCR. They noted they might "add a mokuro local server for this to increase accuracy for local ocr just for this purpose," then closed the issue as part of rewriting Mangatan into a proper app.

**The rewrite already delivers exactly what the issue asked for:**

- Bulk download already exists (detail view: download next 5/10/25, download unread, download all).
- Each downloaded chapter persists the **pre-generated Mokuro `.mokuro` OCR sidecar** via `MokuroSidecarStore` (added in `bb791473` "Add persistent Mokuro OCR support"), so bulk-downloading bulk-caches OCR.
- That path fetches only the Mokuro extension's pre-generated OCR from `mokuro.moe`, **never** the live Google Lens endpoint (`ChromeLensOcrClient`). Live OCR stays strictly per-page / on-demand in the reader and video overlays — precisely the "don't abuse the Google API" constraint from the issue.

So this is a **fix-already-shipped** case. Per the audit rules I did not manufacture a behavior change; instead I added the missing regression coverage and documentation for the one bulk-specific safety invariant that was untested.

## What this PR adds

- **Regression test** (`test/services/mining/mokuro_sidecar_test.dart`): when a bulk download races many chapters of the **same Mokuro volume** before any sidecar exists on disk, the shared in-memory volume cache must collapse them to **a single network fetch** while still writing every sidecar. This guards the exact "bulk download can't hammer the Mokuro server / API" property the issue cared about.
  - The download queue constructs a fresh `MokuroSidecarStore` per chapter, so the test uses N separate stores (as production does) and asserts one fetch across all of them.
  - **Verified meaningful by mutation**: disabling the `MokuroExtensionOcrClient` volume cache makes the test fail with `Actual: <5>` fetches instead of `<1>`. It is not a pass-immediately no-op.
- **Developer documentation** on `MokuroSidecarStore` describing the bulk-caching contract (pre-generated OCR only; static in-flight write map + volume cache collapse concurrent same-target work).

No production behavior change. Test + docs only. No pubspec build bump (not device-testable per AGENTS.md).

## Test plan

```
dart format --output=none --set-exit-if-changed \
  test/services/mining/mokuro_sidecar_test.dart lib/services/mining/mokuro_sidecar.dart
# Formatted 2 files (0 changed)

flutter test test/services/mining/mokuro_sidecar_test.dart
# 00:00 +6: All tests passed!  (new: "bulk downloads dedupe one volume to a single fetch across stores")

git diff --check   # clean
```

Refs #47 (issue is already closed; this PR documents and locks the resolved behavior — it does not reopen or claim to close it).