### PR TITLE
fix(ocr): add spaces between merged OCR lines for spaced languages (refs #30)

### DIFF
--- a/lib/modules/mining/widgets/reader_ocr_overlay.dart
+++ b/lib/modules/mining/widgets/reader_ocr_overlay.dart
@@ -22,6 +22,7 @@ import 'package:mangayomi/services/mining/mokuro_parser.dart';
 import 'package:mangayomi/services/mining/mokuro_sidecar.dart';
 import 'package:mangayomi/services/mining/ocr_models.dart';
 import 'package:mangayomi/services/mining/ocr_block_merger.dart';
+import 'package:mangayomi/services/mining/ocr_block_reading.dart';
 import 'package:mangayomi/services/mining/profile_ocr_language.dart';
 import 'package:mangayomi/services/mining/screen_ai_ocr.dart';
 import 'package:mangayomi/utils/extensions/others.dart';
@@ -862,7 +863,7 @@ class ReaderOcrController extends ChangeNotifier {
         _paintOcrBox(
           canvas: canvas,
           rect: rect,
-          text: _orderedBlock(block),
+          text: orderedBlockSentence(block),
           vertical: block.vertical,
           active: active,
           backgroundOpacity: backgroundOpacity,
@@ -870,7 +871,7 @@ class ReaderOcrController extends ChangeNotifier {
           highlight: active
               ? _lineHighlightFor(
                   lineStart: 0,
-                  lineLength: _orderedBlock(block).length,
+                  lineLength: orderedBlockSentence(block).length,
                   rect: rect,
                   vertical: block.vertical,
                 )
@@ -1037,9 +1038,9 @@ class ReaderOcrController extends ChangeNotifier {
   }
 
   void _prefetchHit(_OcrTapHit hit) {
-    final ordered = _orderedBlock(hit.block);
+    final ordered = orderedBlockSentence(hit.block);
     if (ordered.isEmpty) return;
-    final orderedOffset = _toOrderedOffset(
+    final orderedOffset = toOrderedOffset(
       hit.block,
       hit.rawOffset,
     ).clamp(0, ordered.length - 1);
@@ -1119,9 +1120,9 @@ class ReaderOcrController extends ChangeNotifier {
       DictionaryLookupPopup.dismissActive();
       return true;
     }
-    final ordered = _orderedBlock(block);
+    final ordered = orderedBlockSentence(block);
     if (ordered.isEmpty) return true;
-    final orderedOffset = _toOrderedOffset(
+    final orderedOffset = toOrderedOffset(
       block,
       rawOffset,
     ).clamp(0, ordered.length - 1);
@@ -1640,49 +1641,6 @@ class _ReaderOcrPage {
   final double boxScaleX;
   final double boxScaleY;
   final bool usesMokuroWebsiteData;
-}
-
-List<int> _orderedLineIndices(OcrTextBlock block) {
-  final indices = List.generate(block.lines.length, (index) => index);
-  if (block.lines.length <= 1 ||
-      block.lineGeometries.length != block.lines.length) {
-    return indices;
-  }
-  if (block.vertical) {
-    indices.sort((a, b) {
-      final ax = block.lineGeometries[a].xmin + block.lineGeometries[a].xmax;
-      final bx = block.lineGeometries[b].xmin + block.lineGeometries[b].xmax;
-      return bx.compareTo(ax);
-    });
-  } else {
-    indices.sort(
-      (a, b) =>
-          block.lineGeometries[a].ymin.compareTo(block.lineGeometries[b].ymin),
-    );
-  }
-  return indices;
-}
-
-String _orderedBlock(OcrTextBlock block) =>
-    _orderedLineIndices(block).map((index) => block.lines[index]).join();
-
-int _toOrderedOffset(OcrTextBlock block, int rawOffset) {
-  var start = 0;
-  var rawLine = 0;
-  var inLine = 0;
-  for (var index = 0; index < block.lines.length; index++) {
-    if (rawOffset < start + block.lines[index].length) {
-      rawLine = index;
-      inLine = rawOffset - start;
-      break;
-    }
-    start += block.lines[index].length;
-  }
-  final order = _orderedLineIndices(block);
-  return order
-          .takeWhile((index) => index != rawLine)
-          .fold<int>(0, (sum, index) => sum + block.lines[index].length) +
-      inLine;
 }
 
 int _characterOffset(OcrTextBlock block, Offset local, Size size) {

--- a/lib/services/mining/ocr_block_merger.dart
+++ b/lib/services/mining/ocr_block_merger.dart
@@ -2,6 +2,47 @@ import 'dart:math' as math;
 
 import 'package:mangayomi/services/mining/ocr_models.dart';
 
+/// Languages whose scripts do not use spaces between words.
+///
+/// OCR reconstructs a block as a list of lines. For these scripts the lines
+/// must be concatenated with no separator; for every other language the lines
+/// are separate words/phrases and need a single space, otherwise the mined
+/// sentence runs words together (Mangatan issue #30).
+bool ocrLanguageUsesSpaces(String language) {
+  final code = language.trim().toLowerCase();
+  if (code.isEmpty) return true;
+  // Japanese, Chinese (all variants), and other spaceless CJK scripts.
+  const spaceless = ['ja', 'zh', 'yue', 'wuu', 'hak', 'nan', 'lzh', 'cmn'];
+  for (final prefix in spaceless) {
+    if (code == prefix ||
+        code.startsWith('$prefix-') ||
+        code.startsWith('${prefix}_')) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Joins OCR lines of a single block into one readable string.
+///
+/// Spaced languages get a single space between lines, collapsing any spacing
+/// the fragments already carry so a line ending or starting with whitespace is
+/// not doubled. CJK/spaceless languages are concatenated verbatim.
+String joinOcrLines(Iterable<String> lines, {required String language}) {
+  final parts = lines.where((line) => line.isNotEmpty).toList();
+  if (parts.isEmpty) return '';
+  if (!ocrLanguageUsesSpaces(language)) return parts.join();
+  final buffer = StringBuffer(parts.first);
+  for (var i = 1; i < parts.length; i++) {
+    final previous = parts[i - 1];
+    final current = parts[i];
+    final needsSpace = !previous.endsWith(' ') && !current.startsWith(' ');
+    if (needsSpace) buffer.write(' ');
+    buffer.write(current);
+  }
+  return buffer.toString();
+}
+
 /// Reconstructs OCR engine line fragments into readable text blocks.
 ///
 /// This follows Chimahon's OwOCR stages: fragment joining, furigana filtering,
@@ -15,7 +56,7 @@ List<OcrTextBlock> mergeOcrBlocks(
   var lines = _flatten(blocks);
   if (lines.isEmpty) return const [];
   lines = _deduplicate(lines);
-  lines = _mergeBrokenFragments(lines);
+  lines = _mergeBrokenFragments(lines, language);
   if (language.startsWith('ja')) lines = _filterFurigana(lines);
   var groups = _components(lines, _sameParagraph);
   groups = _mergeCloseGroups(groups);
@@ -71,7 +112,7 @@ List<_Line> _deduplicate(List<_Line> lines) {
   return kept;
 }
 
-List<_Line> _mergeBrokenFragments(List<_Line> lines) {
+List<_Line> _mergeBrokenFragments(List<_Line> lines, String language) {
   final remaining = [...lines];
   final output = <_Line>[];
   while (remaining.isNotEmpty) {
@@ -89,7 +130,9 @@ List<_Line> _mergeBrokenFragments(List<_Line> lines) {
         }
       }
     }
-    output.add(group.length == 1 ? seed : _joinLine(group, seed.vertical));
+    output.add(
+      group.length == 1 ? seed : _joinLine(group, seed.vertical, language),
+    );
   }
   return output;
 }
@@ -107,14 +150,14 @@ bool _brokenPair(_Line a, _Line b) {
           math.max(a.charSize, b.charSize) * 0.5;
 }
 
-_Line _joinLine(List<_Line> lines, bool vertical) {
+_Line _joinLine(List<_Line> lines, bool vertical, String language) {
   lines.sort(
     (a, b) => vertical
         ? a.centerY.compareTo(b.centerY)
         : a.centerX.compareTo(b.centerX),
   );
   return _Line(
-    _clean(lines.map((line) => line.text).join()),
+    _clean(joinOcrLines(lines.map((line) => line.text), language: language)),
     _union(lines.map((line) => line.box)),
     vertical,
     lines.first.language,

--- a/lib/services/mining/ocr_block_reading.dart
+++ b/lib/services/mining/ocr_block_reading.dart
@@ -1,0 +1,81 @@
+import 'package:mangayomi/services/mining/ocr_block_merger.dart';
+import 'package:mangayomi/services/mining/ocr_models.dart';
+
+/// Reading-order and sentence-assembly helpers for OCR text blocks.
+///
+/// A block holds its lines as separate strings. When we reconstruct the
+/// sentence for display, copy, dictionary lookup, or Anki mining, spaced
+/// languages need a single space between lines while CJK/spaceless languages
+/// are concatenated verbatim (Mangatan issue #30). All consumers must use the
+/// same joining and the same offset mapping so highlight/lookup offsets stay
+/// aligned with the assembled sentence.
+
+/// Returns the block's line indices in natural reading order.
+///
+/// Vertical Japanese columns read right-to-left; horizontal lines read
+/// top-to-bottom. Falls back to the stored order when geometry is unavailable.
+List<int> orderedBlockLineIndices(OcrTextBlock block) {
+  final indices = List.generate(block.lines.length, (index) => index);
+  if (block.lines.length <= 1 ||
+      block.lineGeometries.length != block.lines.length) {
+    return indices;
+  }
+  if (block.vertical) {
+    indices.sort((a, b) {
+      final ax = block.lineGeometries[a].xmin + block.lineGeometries[a].xmax;
+      final bx = block.lineGeometries[b].xmin + block.lineGeometries[b].xmax;
+      return bx.compareTo(ax);
+    });
+  } else {
+    indices.sort(
+      (a, b) =>
+          block.lineGeometries[a].ymin.compareTo(block.lineGeometries[b].ymin),
+    );
+  }
+  return indices;
+}
+
+/// The block's lines in reading order.
+List<String> orderedBlockLines(OcrTextBlock block) =>
+    orderedBlockLineIndices(block).map((index) => block.lines[index]).toList();
+
+/// The block reconstructed into a single sentence in reading order.
+///
+/// Uses [joinOcrLines] so spaced languages get one space between lines and
+/// spaceless languages are concatenated.
+String orderedBlockSentence(OcrTextBlock block) =>
+    joinOcrLines(orderedBlockLines(block), language: block.language);
+
+/// Maps a raw character offset (into the naive concatenation of [block.lines]
+/// in stored order) onto the offset within [orderedBlockSentence].
+///
+/// Accounts for both reading-order reshuffling and any separators inserted by
+/// [joinOcrLines], so a tap position resolves to the correct character in the
+/// assembled sentence.
+int toOrderedOffset(OcrTextBlock block, int rawOffset) {
+  var start = 0;
+  var rawLine = 0;
+  var inLine = 0;
+  for (var index = 0; index < block.lines.length; index++) {
+    if (rawOffset < start + block.lines[index].length) {
+      rawLine = index;
+      inLine = rawOffset - start;
+      break;
+    }
+    start += block.lines[index].length;
+  }
+  final order = orderedBlockLineIndices(block);
+  final preceding = order.takeWhile((index) => index != rawLine).toList();
+  if (preceding.isEmpty) return inLine;
+  // Rebuild the assembled prefix (ordered preceding lines + the current line)
+  // and measure it: this yields the exact offset including inserted spaces
+  // without re-deriving joinOcrLines' whitespace rules here.
+  final prefixLines = [
+    ...preceding.map((i) => block.lines[i]),
+    block.lines[rawLine],
+  ];
+  final assembledPrefix = joinOcrLines(prefixLines, language: block.language);
+  final currentLine = block.lines[rawLine];
+  final currentStartInPrefix = assembledPrefix.length - currentLine.length;
+  return currentStartInPrefix + inLine;
+}

--- a/test/services/mining/ocr_block_merger_test.dart
+++ b/test/services/mining/ocr_block_merger_test.dart
@@ -25,6 +25,57 @@ void main() {
 
     expect(merged.single.lines, ['right', 'left']);
   });
+
+  test(
+    'inserts a space when joining broken fragments for spaced languages',
+    () {
+      final blocks = [
+        _block('hello', 0.10, 0.10, 0.25, 0.15),
+        _block('world', 0.255, 0.10, 0.45, 0.15),
+      ];
+
+      final merged = mergeOcrBlocks(blocks, language: 'en');
+
+      expect(merged, hasLength(1));
+      expect(merged.single.lines, ['hello world']);
+    },
+  );
+
+  group('joinOcrLines', () {
+    test('joins CJK lines without a separator', () {
+      expect(joinOcrLines(['今日は', 'いい天気'], language: 'ja'), '今日はいい天気');
+      expect(joinOcrLines(['你好', '世界'], language: 'zh'), '你好世界');
+    });
+
+    test('joins spaced-language lines with a single space', () {
+      expect(joinOcrLines(['hello', 'world'], language: 'en'), 'hello world');
+    });
+
+    test(
+      'does not add a space when a line already ends or starts with one',
+      () {
+        expect(
+          joinOcrLines(['hello ', 'world'], language: 'en'),
+          'hello world',
+        );
+        expect(
+          joinOcrLines(['hello', ' world'], language: 'en'),
+          'hello world',
+        );
+      },
+    );
+
+    test('drops empty lines without leaving stray separators', () {
+      expect(
+        joinOcrLines(['hello', '', 'world'], language: 'en'),
+        'hello world',
+      );
+    });
+
+    test('treats an unknown/empty language as spaced', () {
+      expect(joinOcrLines(['foo', 'bar'], language: ''), 'foo bar');
+    });
+  });
 }
 
 OcrTextBlock _block(

--- a/test/services/mining/ocr_block_reading_test.dart
+++ b/test/services/mining/ocr_block_reading_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/mining/ocr_block_reading.dart';
+import 'package:mangayomi/services/mining/ocr_models.dart';
+
+void main() {
+  group('orderedBlockSentence', () {
+    test('concatenates CJK lines without separators', () {
+      final block = OcrTextBlock(
+        xmin: 0,
+        ymin: 0,
+        xmax: 1,
+        ymax: 1,
+        lines: ['今日は', 'いい天気'],
+        lineGeometries: [
+          OcrLineGeometry(xmin: 0, ymin: 0.0, xmax: 1, ymax: 0.4),
+          OcrLineGeometry(xmin: 0, ymin: 0.5, xmax: 1, ymax: 0.9),
+        ],
+        language: 'ja',
+      );
+
+      expect(orderedBlockSentence(block), '今日はいい天気');
+    });
+
+    test('joins spaced-language lines with a single space', () {
+      final block = OcrTextBlock(
+        xmin: 0,
+        ymin: 0,
+        xmax: 1,
+        ymax: 1,
+        lines: ['the quick', 'brown fox'],
+        lineGeometries: [
+          OcrLineGeometry(xmin: 0, ymin: 0.0, xmax: 1, ymax: 0.4),
+          OcrLineGeometry(xmin: 0, ymin: 0.5, xmax: 1, ymax: 0.9),
+        ],
+        language: 'en',
+      );
+
+      expect(orderedBlockSentence(block), 'the quick brown fox');
+    });
+
+    test('orders horizontal lines top to bottom', () {
+      final block = OcrTextBlock(
+        xmin: 0,
+        ymin: 0,
+        xmax: 1,
+        ymax: 1,
+        lines: ['second', 'first'],
+        lineGeometries: [
+          OcrLineGeometry(xmin: 0, ymin: 0.5, xmax: 1, ymax: 0.9),
+          OcrLineGeometry(xmin: 0, ymin: 0.0, xmax: 1, ymax: 0.4),
+        ],
+        language: 'en',
+      );
+
+      expect(orderedBlockSentence(block), 'first second');
+    });
+  });
+
+  group('toOrderedOffset', () {
+    test('maps raw offset within first line unchanged', () {
+      final block = _spacedTwoLineBlock();
+      // raw offset 2 => inside "the" ('e'), ordered string "the brown"
+      expect(toOrderedOffset(block, 2), 2);
+    });
+
+    test('accounts for the inserted separator on later lines (spaced)', () {
+      // lines: ['the', 'brown'] -> ordered "the brown"
+      // raw offset 3 is start of "brown" (raw concat "thebrown").
+      // In the ordered "the brown", "brown" starts at index 4 (after space).
+      final block = _spacedTwoLineBlock();
+      expect(toOrderedOffset(block, 3), 4);
+    });
+
+    test('does not shift offsets for CJK (no separators)', () {
+      final block = OcrTextBlock(
+        xmin: 0,
+        ymin: 0,
+        xmax: 1,
+        ymax: 1,
+        lines: ['あい', 'うえ'],
+        lineGeometries: [
+          OcrLineGeometry(xmin: 0, ymin: 0.0, xmax: 1, ymax: 0.4),
+          OcrLineGeometry(xmin: 0, ymin: 0.5, xmax: 1, ymax: 0.9),
+        ],
+        language: 'ja',
+      );
+      // raw concat "あいうえ", offset 2 == start of second line, ordered same.
+      expect(toOrderedOffset(block, 2), 2);
+    });
+  });
+}
+
+OcrTextBlock _spacedTwoLineBlock() => OcrTextBlock(
+  xmin: 0,
+  ymin: 0,
+  xmax: 1,
+  ymax: 1,
+  lines: ['the', 'brown'],
+  lineGeometries: [
+    OcrLineGeometry(xmin: 0, ymin: 0.0, xmax: 1, ymax: 0.4),
+    OcrLineGeometry(xmin: 0, ymin: 0.5, xmax: 1, ymax: 0.9),
+  ],
+  language: 'en',
+);


### PR DESCRIPTION
## Summary

Historical issue #30 ("the bounding box or whatever is called") reported that
Mangatan's OCR text extraction ran words together when mining/copying — the
bounding-box text "just sends the word", and merged sentences had words stuck
together. In the userscript era this was resolved by adding an **"add space when
merging"** option (see @1Selxo's closing comment: *"It doesn't add space when
merging it just basically throws the sentence together and it worked well with
Japanese ... I'll add option to add space between merged sentence to fix this"*).

Auditing the **current** Flutter/OCR rewrite, that behavior was never carried
forward. The rewrite reintroduced the exact same class of bug:

- `reader_ocr_overlay.dart` assembled the copyable / dictionary-lookup / Anki
  **mining sentence** from a block's lines with a bare `List.join()` (no
  separator).
- `ocr_block_merger.dart` joined broken horizontal line fragments the same way.

Concatenating with no separator is correct for CJK/spaceless scripts (Japanese,
Chinese) — which is why the original author, studying Japanese, never hit it —
but wrong for every space-using language, producing `helloworld` instead of
`hello world`.

## Changes

- **`ocr_block_merger.dart`**: add language-aware `joinOcrLines()` +
  `ocrLanguageUsesSpaces()`. Spaceless scripts concatenate verbatim; all other
  languages get a single space between lines (idempotent when a line already
  carries edge whitespace). Use it when joining broken line fragments.
- **`ocr_block_reading.dart`** (new): extract reading-order + sentence assembly
  (`orderedBlockSentence` / `toOrderedOffset` / `orderedBlockLineIndices`) so the
  reader overlay produces the same spaced sentence **and** keeps dictionary
  lookup / highlight offsets aligned with the inserted separators.
- **`reader_ocr_overlay.dart`**: use the shared helpers; drop the duplicated
  private ordering/offset functions.

Pure Dart logic (manga reader OCR), no device/IPA surface, so per `AGENTS.md`
the `pubspec.yaml` build number is **not** bumped.

## Test Plan (RED → GREEN, TDD)

New focused coverage:

- `test/services/mining/ocr_block_merger_test.dart` — join semantics (CJK vs
  spaced, whitespace idempotency, empty lines, unknown language) and
  space-insertion when merging broken fragments.
- `test/services/mining/ocr_block_reading_test.dart` — reading order and
  raw→ordered offset mapping across the inserted separators.

Verification on this Linux host:

- `flutter test test/services/mining/ocr_block_merger_test.dart test/services/mining/ocr_block_reading_test.dart` → **14/14 pass**
- `flutter test test/services/mining/` → 131 pass; the only 2 failures
  (`animated_avif_validator_test`, `desktop_scene_capture_test`) are
  pre-existing on a clean checkout (require native AVIF tooling absent here),
  not caused by this change.
- `flutter analyze` on the touched files → no issues.
- `dart format --set-exit-if-changed` → clean.
- `git diff --check` → clean.

Refs #30 (issue is already closed/completed; this PR restores the resolved
behavior in the current rewrite and adds regression tests — it does not claim to
close the issue).
