### PR TITLE
docs: clarify in-app OCR engines (issue #31)

### DIFF
--- a/docs/ocr_engines.md
+++ b/docs/ocr_engines.md
@@ -1,0 +1,97 @@
+# OCR engines
+
+This document answers the questions raised in
+[issue #31](https://github.com/1Selxo/Mangatan/issues/31) ("General
+Clarifications") for the current, rewritten Mangatan codebase.
+
+Issue #31 was filed against the old userscript-era setup, which shipped OCR as
+a set of separate Python servers (`ocr-server`, `ocr-server-legacy`, a
+"combined server", and a Windows Snipping Tool / `oneocr.dll` flow copied into
+`.config/oneocr`). **None of those components exist in Mangatan.** OCR is now
+performed entirely inside the app; there is no Python server to install, no
+`server(local-ocr).py`, no legacy/combined server distinction, and no manual
+`oneocr.dll` extraction step. This page documents what replaced them so the
+original questions have an accurate, current answer.
+
+## Where OCR is selected
+
+The OCR engine is a single user setting, not a choice of which server binary to
+run. It is stored as
+[`OcrEnginePreference`](../lib/services/mining/mining_preferences.dart) and
+exposed in the reader's settings modal under **OCR engine**
+([`reader_settings_modal.dart`](../lib/modules/manga/reader/widgets/reader_settings_modal.dart)).
+
+```dart
+enum OcrEnginePreference { automatic, screenAi, googleLens, mokuroOnly }
+```
+
+The default is `automatic`.
+
+## The engines
+
+| Setting | Runs | Network | Platform | Notes |
+| --- | --- | --- | --- | --- |
+| `automatic` | Mokuro → ScreenAI → Google Lens (in that order) | Only if it falls through to Google Lens | Any | Default. Uses whatever is available for each page. |
+| `screenAi` | On-device ScreenAI (native DLL over FFI) | None | Windows only | The modern "local OCR". No manual file setup — see below. |
+| `googleLens` | Google Lens | Yes (sends the page image to Google) | Any | Cloud OCR. |
+| `mokuroOnly` | Pre-computed Mokuro data only | None | Any | Never runs live OCR; shows only pre-generated Mokuro boxes. |
+
+### `automatic` cascade
+
+For a manga reader page, `automatic` resolves in this order
+([`reader_ocr_overlay.dart`](../lib/modules/mining/widgets/reader_ocr_overlay.dart),
+`_recognize`):
+
+1. **Mokuro sidecar / pre-computed data.** If a matching `.mokuro` volume is
+   found for the page, its boxes are used directly. No live OCR runs.
+2. **Mokuro website OCR**, when that option is enabled and a volume can be
+   fetched for the source.
+3. **ScreenAI**, when `ScreenAiOcrClient.isAvailable()` is true (Windows, the
+   native bridge is present, and the ScreenAI component directory exists). This
+   is on-device and needs no network.
+4. **Google Lens**, as the final fallback. This is the only step that leaves the
+   device.
+
+`screenAi` and `googleLens` pin the engine to that single backend (skipping the
+Mokuro pre-pass); `mokuroOnly` uses pre-computed data and never runs live OCR.
+
+Video OCR follows the same ScreenAI-then-Google-Lens logic and rejects
+`mokuroOnly` because there is no pre-computed data for arbitrary video frames
+([`video_ocr_overlay.dart`](../lib/modules/anime/widgets/video_ocr_overlay.dart)).
+
+## Local (ScreenAI) vs cloud (Google Lens)
+
+This is the modern form of issue #31's "local OCR vs Google Lens" question. The
+Chimahon settings sync even labels them exactly that way
+([`chimahon_mining_settings_adapter.dart`](../lib/services/sync/chimahon_mining_settings_adapter.dart)):
+`screenAi` exports as `local`, `googleLens` as `cloud`.
+
+- **ScreenAI (local):**
+  - Runs on-device; **no image is sent to any server**.
+  - Works offline.
+  - Avoids depending on / hammering the Google Lens endpoint.
+  - **Windows only** in the current build (the FFI bridge in
+    [`windows/runner/screen_ai_bridge.cpp`](../windows/runner/screen_ai_bridge.cpp)).
+- **Google Lens (cloud):**
+  - Cross-platform.
+  - Requires network; the page image is uploaded to Google.
+
+Accuracy between the two is comparable for typical manga pages; the practical
+difference is privacy/offline capability (ScreenAI) versus availability on every
+platform (Google Lens).
+
+### ScreenAI has no manual setup
+
+Unlike the old flow described in issue #31, you do **not** download the Snipping
+Tool, extract `oneocr.dll` / `oneocr.onemodel` / `onnxruntime.dll`, or copy
+anything into `.config/oneocr`. Mangatan locates the ScreenAI component itself
+([`screen_ai_ocr.dart`](../lib/services/mining/screen_ai_ocr.dart),
+`_findComponentDirectory`). If the component is not present, `automatic` simply
+falls through to Google Lens.
+
+## Keeping this document accurate
+
+`test/services/mining/ocr_engine_docs_test.dart` asserts that every value of
+`OcrEnginePreference` is named in this file. If an engine is added or renamed,
+that test fails until this document is updated — preventing the code/docs drift
+that issue #31 originally reported.

--- a/test/services/mining/ocr_engine_docs_test.dart
+++ b/test/services/mining/ocr_engine_docs_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/mining/mining_preferences.dart';
+
+/// Regression guard for issue #31 ("General Clarifications").
+///
+/// Issue #31 reported that the OCR setup documentation did not match the
+/// engines the app actually shipped (naming drift, undocumented "combined"
+/// behaviour, and unclear local-vs-cloud tradeoffs). The Python OCR-server
+/// subsystem the issue referenced no longer exists; OCR is now fully in-app
+/// and selected via [OcrEnginePreference]. This test keeps the user/developer
+/// documentation of that resolved behaviour from silently drifting away from
+/// the enum again: every OCR engine the app can select MUST be named in
+/// docs/ocr_engines.md.
+void main() {
+  final docFile = File('docs/ocr_engines.md');
+
+  test('OCR engine documentation exists', () {
+    expect(
+      docFile.existsSync(),
+      isTrue,
+      reason:
+          'docs/ocr_engines.md must document the in-app OCR engines (issue #31).',
+    );
+  });
+
+  test('documentation names every selectable OCR engine', () {
+    final contents = docFile.readAsStringSync();
+    for (final engine in OcrEnginePreference.values) {
+      expect(
+        contents.contains(engine.name),
+        isTrue,
+        reason:
+            'docs/ocr_engines.md must document OcrEnginePreference.${engine.name}. '
+            'If an engine is added or renamed, update the documentation so the '
+            'setup guide never drifts from the code again (issue #31).',
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Issue #31 (closed) asked for clarification of the OCR setup. It was filed
against the old userscript-era architecture, which shipped OCR as separate
Python servers (`ocr-server`, `ocr-server-legacy`, a "combined server") plus a
manual Windows Snipping Tool / `oneocr.dll` extraction into `.config/oneocr`.

That subsystem no longer exists in this repo. OCR is now fully **in-app** and
selected via a single setting, `OcrEnginePreference { automatic, screenAi,
googleLens, mokuroOnly }`. This PR does not resurrect the obsolete Python
concepts (documenting them would be misleading) — it documents the **current,
resolved** behaviour so the original questions finally have an accurate answer,
and guards that documentation against drift.

## What's added

- `docs/ocr_engines.md` — explains, grounded in the current code:
  - which engines exist and the `automatic` cascade
    (Mokuro → ScreenAI → Google Lens), from `reader_ocr_overlay.dart`;
  - local (ScreenAI, on-device, Windows-only, no network) vs cloud
    (Google Lens) tradeoffs — the modern form of the issue's "local OCR vs
    Google Lens" question (Chimahon sync even labels them `local`/`cloud`);
  - that ScreenAI requires **no** manual `oneocr.dll`/`.config/oneocr` setup
    (the component is located automatically).
- `test/services/mining/ocr_engine_docs_test.dart` — a doc-drift regression
  test asserting every `OcrEnginePreference` value is documented, so the setup
  docs can never silently diverge from the code again (the exact class of
  problem issue #31 reported).

## Verification (Linux host)

- `flutter test test/services/mining/ocr_engine_docs_test.dart` → **All tests
  passed** (written test-first: confirmed RED before the doc existed, then
  GREEN).
- `flutter test test/services/mining/` → 121 passed; the only 2 failures are
  pre-existing and unrelated (they require `ffmpeg`, which is absent on this
  host — AVIF/scene-capture tests).
- `flutter test test/services/m_extension_server_test.dart` → All tests passed
  (AGENTS.md required).
- `dart format --set-exit-if-changed` on new/required test → clean.
- `flutter analyze` on the new test → No issues found.
- `git diff --check` → clean.

No `pubspec` build-number bump: this is documentation + a test, not a
device-testable native change (AGENTS.md requires the bump only for a
device-testable IPA).

Refs #31 (already closed; this clarifies the resolved behaviour, it does not
reopen or close the issue).
