### PR TITLE
fix(mining): keep OCR sentence continuous across merged lines (#45)

### DIFF
--- a/lib/modules/anime/widgets/video_ocr_overlay.dart
+++ b/lib/modules/anime/widgets/video_ocr_overlay.dart
@@ -170,9 +170,9 @@ class _VideoOcrOverlayState extends State<VideoOcrOverlay> {
     _popup?.dismiss();
     setState(() => _selection = selection);
     final resolvedMiningContext =
-        _frameMiningContext?.copyWith(sentence: block.text) ??
+        _frameMiningContext?.copyWith(sentence: block.sentence) ??
         await widget.miningContextBuilder(
-          block.text,
+          block.sentence,
           widget.imageBytes,
           widget.imagePosition,
         );
@@ -491,9 +491,9 @@ class _LiveVideoOcrOverlayState extends State<LiveVideoOcrOverlay> {
     final frame = _recognizedFrame;
     if (frame == null) return;
     final resolvedMiningContext =
-        _recognizedMiningContext?.copyWith(sentence: block.text) ??
+        _recognizedMiningContext?.copyWith(sentence: block.sentence) ??
         await widget.miningContextBuilder(
-          block.text,
+          block.sentence,
           frame.bytes,
           frame.position,
         );
@@ -759,7 +759,7 @@ _VideoOcrSelection _videoOcrSelectionAtPosition(
   Rect rect,
   Offset globalPosition,
 ) {
-  final text = block.text.replaceAll('\n', '');
+  final text = block.sentence;
   if (text.isEmpty || rect.isEmpty) {
     return _VideoOcrSelection(block: block, text: '', offset: 0);
   }

--- a/lib/services/mining/ocr_models.dart
+++ b/lib/services/mining/ocr_models.dart
@@ -36,4 +36,13 @@ class OcrTextBlock {
   });
 
   String get text => lines.where((line) => line.trim().isNotEmpty).join('\n');
+
+  /// The block's lines joined into a single continuous sentence.
+  ///
+  /// Unlike [text], this never inserts a hard newline between merged OCR
+  /// lines. A raw `\n` between auto-merged fragments makes downstream
+  /// sentence extraction (Yomitan) stop at the first line and produces an
+  /// incomplete Anki sentence field. Use this whenever a block is handed to a
+  /// dictionary popup or mining context as the example sentence.
+  String get sentence => lines.where((line) => line.trim().isNotEmpty).join();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mangayomi
 description: Free and open source manga reader and anime streaming
   cross-plateform app inspired by Tachiyomi and Aniyomi.
 publish_to: "none"
-version: 1.2.0+170
+version: 1.2.0+171
 
 environment:
   sdk: ^3.12.2

--- a/test/services/mining/ocr_block_merger_test.dart
+++ b/test/services/mining/ocr_block_merger_test.dart
@@ -25,6 +25,23 @@ void main() {
 
     expect(merged.single.lines, ['right', 'left']);
   });
+
+  test('merged multi-line block yields a newline-free sentence', () {
+    // Regression for issue #45: auto-merged OCR lines produced a sentence with
+    // a hard newline between them, so Yomitan / Anki received an incomplete
+    // sentence. The merged block's `sentence` must be one continuous string.
+    final blocks = [
+      _block('これは', 0.30, 0.10, 0.35, 0.40, vertical: true),
+      _block('文です', 0.24, 0.10, 0.29, 0.40, vertical: true),
+    ];
+
+    final merged = mergeOcrBlocks(blocks, language: 'ja');
+
+    expect(merged, hasLength(1));
+    expect(merged.single.lines.length, greaterThan(1));
+    expect(merged.single.sentence, 'これは文です');
+    expect(merged.single.sentence.contains('\n'), isFalse);
+  });
 }
 
 OcrTextBlock _block(

--- a/test/services/mining/ocr_models_sentence_test.dart
+++ b/test/services/mining/ocr_models_sentence_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/mining/ocr_models.dart';
+
+void main() {
+  group('OcrTextBlock.sentence', () {
+    test('joins merged OCR lines into one continuous sentence', () {
+      // A single OCR text block whose lines were auto-merged from separate
+      // detected fragments. Regression for issue #45: Yomitan / Anki received
+      // an incomplete sentence because a hard newline sat between the merged
+      // lines, so downstream sentence extraction stopped at the first line.
+      final block = OcrTextBlock(
+        xmin: 0,
+        ymin: 0,
+        xmax: 1,
+        ymax: 1,
+        lines: const ['これは', '一つの文です'],
+      );
+
+      expect(block.sentence, 'これは一つの文です');
+      expect(block.sentence.contains('\n'), isFalse);
+    });
+
+    test('drops blank lines when building the sentence', () {
+      final block = OcrTextBlock(
+        xmin: 0,
+        ymin: 0,
+        xmax: 1,
+        ymax: 1,
+        lines: const ['前半', '   ', '後半'],
+      );
+
+      expect(block.sentence, '前半後半');
+    });
+
+    test('text getter still exposes the newline-joined form', () {
+      final block = OcrTextBlock(
+        xmin: 0,
+        ymin: 0,
+        xmax: 1,
+        ymax: 1,
+        lines: const ['A', 'B'],
+      );
+
+      expect(block.text, 'A\nB');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the class of bug reported in #45 — "although lines are merged, the sentence is not complete. Newline inside, maybe?" — in the **current** codebase.

When OCR detects multiple lines inside one text block (auto-merged fragments), `OcrTextBlock.text` joins those lines with a hard `\n`. The video/anime OCR overlay passed that raw `block.text` straight through as the **example sentence** for the dictionary popup / Anki mining context. A literal newline inside the sentence makes downstream sentence extraction (Yomitan) stop at the first line and produces an incomplete Anki `sentence` field — exactly the reported symptom.

Notably the code already knew newlines were harmful: the *lookup* selection did `block.text.replaceAll('\n', '')`, but the *sentence* did not get the same treatment.

## Changes

- `lib/services/mining/ocr_models.dart` — add `OcrTextBlock.sentence`, which joins non-blank lines with **no separator** (one continuous string). `text` (newline-joined) is unchanged for existing display/signature uses.
- `lib/modules/anime/widgets/video_ocr_overlay.dart` — pass `block.sentence` (not `block.text`) as the mining sentence in both the frozen-frame and recognized-frame paths, and use it as the single source of truth for the lookup selection (replaces the ad-hoc `replaceAll('\n','')`).
- `pubspec.yaml` — bump build number `170 → 171` per AGENTS.md (runtime, device-testable change).

The manga reader OCR path (`reader_ocr_overlay.dart`) was already correct — it builds the sentence via `_orderedBlock`, which joins with an empty separator. This PR brings the video/anime OCR path in line with it.

## Tests

- `test/services/mining/ocr_models_sentence_test.dart` (new) — `OcrTextBlock.sentence` joins merged lines with no newline, drops blank lines, and `text` still exposes the newline-joined form. Written test-first (RED → GREEN).
- `test/services/mining/ocr_block_merger_test.dart` — new end-to-end regression: a multi-line merged block yields a newline-free, continuous sentence.

## Verification (Linux host)

```
flutter test test/services/mining/ocr_models_sentence_test.dart \
             test/services/mining/ocr_block_merger_test.dart
  All tests passed! (6 tests)

flutter test test/services/mining/ test/modules/mining/
  164 passed; 2 pre-existing failures unrelated to this change
  (animated_avif_validator_test / desktop_scene_capture_test — require
   ffmpeg, missing on this host; fail identically on baseline)

flutter analyze <touched files>            -> No issues found!
dart format --set-exit-if-changed <touched> -> clean
git diff --check                            -> clean

# AGENTS.md pre-push checklist
dart format --set-exit-if-changed test/services/m_extension_server_test.dart -> clean
flutter test test/services/m_extension_server_test.dart -> All tests passed!
```

Refs #45 (issue was already closed historically; this PR does not claim to close it).
