### PR TITLE
fix(ocr): keep Japanese block reading order right-to-left for staggered layouts (#44)

### DIFF
--- a/lib/services/mining/ocr_block_merger.dart
+++ b/lib/services/mining/ocr_block_merger.dart
@@ -249,14 +249,32 @@ OcrTextBlock _toBlock(List<_Line> lines, String language) {
 }
 
 List<OcrTextBlock> _readingOrder(List<OcrTextBlock> blocks, bool japanese) {
-  blocks.sort((a, b) {
-    final overlap = _overlap(a.ymin, a.ymax, b.ymin, b.ymax);
-    if (overlap > 0.2) {
-      return japanese ? b.xmin.compareTo(a.xmin) : a.xmin.compareTo(b.xmin);
-    }
-    return a.ymin.compareTo(b.ymin);
+  if (blocks.length < 2) return blocks;
+  // Group blocks into horizontal reading rows first, then order within each
+  // row by reading direction, then stack the rows top-to-bottom.
+  //
+  // A single pairwise comparator that mixes "right-to-left when the two blocks
+  // share a vertical band" with "top-to-bottom otherwise" is non-transitive
+  // for staggered layouts (A above C, but A and C each overlap a middle block
+  // B), which makes List.sort produce a corrupted order that can drop the
+  // right-most block out of first place. Banding sidesteps that: comparisons
+  // inside a row use one axis and comparisons between rows use the other, so
+  // each sort key is a proper total order.
+  final rows = _components<OcrTextBlock>(
+    blocks,
+    (a, b) => _overlap(a.ymin, a.ymax, b.ymin, b.ymax) > 0.2,
+  );
+  for (final row in rows) {
+    row.sort(
+      (a, b) => japanese ? b.xmin.compareTo(a.xmin) : a.xmin.compareTo(b.xmin),
+    );
+  }
+  rows.sort((a, b) {
+    final ay = a.map((block) => block.ymin).reduce(math.min);
+    final by = b.map((block) => block.ymin).reduce(math.min);
+    return ay.compareTo(by);
   });
-  return blocks;
+  return [for (final row in rows) ...row];
 }
 
 String _clean(String value) =>

--- a/test/services/mining/ocr_block_merger_test.dart
+++ b/test/services/mining/ocr_block_merger_test.dart
@@ -25,6 +25,68 @@ void main() {
 
     expect(merged.single.lines, ['right', 'left']);
   });
+
+  test('orders staggered Japanese blocks right-to-left despite partial '
+      'vertical overlap between neighbours', () {
+    // A descending "staircase" of vertical text blocks. Each neighbour shares
+    // a little vertical overlap with the next, but the leftmost and rightmost
+    // blocks do not overlap at all. A pairwise right-to-left comparator that
+    // falls back to top-to-bottom only when two blocks fail to overlap is
+    // non-transitive here (A<C by y, B<A by x-overlap, C<B by x-overlap forms
+    // a cycle), so List.sort produces a corrupted order that drops the
+    // right-most block out of first place. Japanese must always read the
+    // right-most block first.
+    final blocks = [
+      _block('A', 0.10, 0.10, 0.18, 0.30, vertical: true), // left
+      _block('B', 0.40, 0.25, 0.48, 0.45, vertical: true), // middle
+      _block('C', 0.70, 0.40, 0.78, 0.60, vertical: true), // right
+    ];
+
+    final merged = mergeOcrBlocks(blocks, language: 'ja');
+
+    expect(merged.map((block) => block.lines.single).toList(), ['C', 'B', 'A']);
+  });
+
+  test(
+    'orders a grid of Japanese blocks right-to-left, then top-to-bottom',
+    () {
+      // Two rows of three vertical blocks each, supplied out of order. Manga
+      // reading order is right-to-left within a row, then down to the next row.
+      final blocks = [
+        _block('R2b', 0.40, 0.62, 0.50, 0.82, vertical: true),
+        _block('R1c', 0.70, 0.11, 0.80, 0.31, vertical: true),
+        _block('R1a', 0.10, 0.10, 0.20, 0.30, vertical: true),
+        _block('R2c', 0.70, 0.61, 0.80, 0.81, vertical: true),
+        _block('R1b', 0.40, 0.12, 0.50, 0.32, vertical: true),
+        _block('R2a', 0.10, 0.60, 0.20, 0.80, vertical: true),
+      ];
+
+      final merged = mergeOcrBlocks(blocks, language: 'ja');
+
+      expect(merged.map((block) => block.lines.single).toList(), [
+        'R1c',
+        'R1b',
+        'R1a',
+        'R2c',
+        'R2b',
+        'R2a',
+      ]);
+    },
+  );
+
+  test('orders non-Japanese staggered blocks left-to-right', () {
+    // Same staggered geometry as the Japanese staircase, but a left-to-right
+    // language must read the left-most block first.
+    final blocks = [
+      _block('A', 0.10, 0.10, 0.18, 0.30, vertical: true), // left
+      _block('B', 0.40, 0.25, 0.48, 0.45, vertical: true), // middle
+      _block('C', 0.70, 0.40, 0.78, 0.60, vertical: true), // right
+    ];
+
+    final merged = mergeOcrBlocks(blocks, language: 'en');
+
+    expect(merged.map((block) => block.lines.single).toList(), ['A', 'B', 'C']);
+  });
 }
 
 OcrTextBlock _block(


### PR DESCRIPTION
## Summary

Issue #44 reported the OCR auto-merger reading Japanese text **left-to-right**
when vertical manga text must read **right-to-left**. Auditing the current
`origin/main` rewrite (`lib/services/mining/ocr_block_merger.dart`, introduced
by `d432d55e` "align OCR and Anki mining with Chimahon") against that report
surfaced a still-live correctness bug in the final block reading-order step.

`_readingOrder` sorted the merged text blocks with a single pairwise
comparator:

- when two blocks shared a vertical band (`y`-overlap > 0.2) → right-to-left by `xmin`
- otherwise → top-to-bottom by `ymin`

That comparator is **non-transitive** for staggered layouts. For a descending
staircase where block `A` sits above `C`, and both partially overlap a middle
block `B`, the pairwise relations form a cycle (`A < C` by y, `B < A` by
x-overlap, `C < B` by x-overlap). `List.sort` (introsort) then produces a
corrupted order that drops the **right-most** block out of first place — the
exact "reads left-to-right" symptom from the issue. Reproduced concretely:
three staggered vertical blocks `A`(left) `B`(mid) `C`(right) returned
`[B, A, C]` instead of `[C, B, A]`.

## Fix

Order in reading **rows** instead of with one mixed comparator:

1. Group blocks into horizontal reading rows via the existing connected-component
   helper over `y`-overlap.
2. Sort each row by reading direction — right-to-left for Japanese, left-to-right
   otherwise.
3. Stack rows top-to-bottom.

Each sort key is now a proper total order, so the result is deterministic and
the right-most Japanese block always reads first. The change is cross-platform
(pure Dart OCR logic, no platform-specific paths).

## Tests

Added focused regression tests to `test/services/mining/ocr_block_merger_test.dart`:

- `orders staggered Japanese blocks right-to-left despite partial vertical overlap between neighbours` — the failing staircase case (was `[B, A, C]`, now `[C, B, A]`).
- `orders a grid of Japanese blocks right-to-left, then top-to-bottom` — full RTL-then-down grid.
- `orders non-Japanese staggered blocks left-to-right` — LTR contrast on identical geometry.

## Verification (Linux host)

```
flutter test test/services/mining/ocr_block_merger_test.dart   # +5 All tests passed
dart format --output=none --set-exit-if-changed <both files>   # exit 0
flutter analyze <both files>                                   # No issues found
flutter test test/services/m_extension_server_test.dart        # +4 All tests passed (AGENTS.md gate)
git diff --check                                               # clean
```

Pre-existing, unrelated AVIF tests in `test/services/mining/` fail on this host
only because `ffmpeg` is not installed (confirmed failing on the pristine
baseline via `git stash`); they are untouched by this change.

No `pubspec` build bump: this is a Dart-only logic fix verified by unit tests
and does not cut a device-testable IPA (per AGENTS.md, the build number bumps
when an IPA is produced).

Refs #44 (issue was already closed; this hardens the resolution rather than
closing it).
