### PR TITLE
Auto-install Mihon proxy server on desktop

### DIFF
--- a/lib/services/extension_server_auto_installer.dart
+++ b/lib/services/extension_server_auto_installer.dart
@@ -1,0 +1,569 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive_io.dart';
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:mangayomi/modules/more/settings/browse/extension_server/extension_server_utils.dart';
+import 'package:path/path.dart' as path;
+
+typedef MakeExtensionServerExecutable = Future<void> Function(String filePath);
+typedef FindSystemExtensionServer =
+    Future<SystemExtensionServerPaths?> Function();
+typedef AutoInstallExtensionServer =
+    Future<SystemExtensionServerPaths> Function();
+
+const _defaultRequestTimeout = Duration(seconds: 30);
+const _defaultMaximumDownloadBytes = 256 * 1024 * 1024;
+const _defaultMaximumExtractedBytes = 1024 * 1024 * 1024;
+const _defaultMaximumArchiveEntries = 20000;
+
+Future<SystemExtensionServerPaths> resolveDesktopExtensionServerPaths({
+  required String configuredJrePath,
+  required String configuredJarPath,
+  required FindSystemExtensionServer findSystemInstall,
+  required AutoInstallExtensionServer autoInstall,
+}) async {
+  if (configuredJrePath.isNotEmpty &&
+      configuredJarPath.isNotEmpty &&
+      await File(configuredJrePath).exists() &&
+      await File(configuredJarPath).exists()) {
+    return SystemExtensionServerPaths(
+      jrePath: configuredJrePath,
+      jarPath: configuredJarPath,
+    );
+  }
+  return await findSystemInstall() ?? await autoInstall();
+}
+
+/// Installs a desktop M-Extension-Server bundle after verifying the
+/// GitHub-published SHA-256 digest.
+///
+/// This class deliberately persists no "attempted" marker. Any network,
+/// checksum, extraction, or swap failure throws, leaves the configured paths
+/// unchanged, and remains eligible for another call on the next launch.
+class ExtensionServerAutoInstaller {
+  final http.Client client;
+  final String assetName;
+  final MakeExtensionServerExecutable makeExecutable;
+  final Duration requestTimeout;
+  final int maximumDownloadBytes;
+  final int maximumExtractedBytes;
+  final int maximumArchiveEntries;
+
+  ExtensionServerAutoInstaller({
+    required this.client,
+    required this.assetName,
+    MakeExtensionServerExecutable? makeExecutable,
+    this.requestTimeout = _defaultRequestTimeout,
+    this.maximumDownloadBytes = _defaultMaximumDownloadBytes,
+    this.maximumExtractedBytes = _defaultMaximumExtractedBytes,
+    this.maximumArchiveEntries = _defaultMaximumArchiveEntries,
+  }) : makeExecutable = makeExecutable ?? _makeExecutable;
+
+  Future<SystemExtensionServerPaths> ensureInstalled(
+    Directory installDirectory,
+  ) async {
+    await _recoverInterruptedInstall(installDirectory);
+    final existing = await _resolveInstalledPaths(installDirectory);
+    if (existing != null) return existing;
+
+    final release = await _fetchRelease();
+    final staging = Directory('${installDirectory.path}.installing');
+    final download = File('${installDirectory.path}.download');
+    final backup = Directory('${installDirectory.path}.previous');
+    var backedUpLiveInstall = false;
+
+    try {
+      await installDirectory.parent.create(recursive: true);
+      await _downloadBundle(release, download);
+      await staging.create(recursive: true);
+      await _extractArchive(download, staging);
+
+      final stagedPaths = await _resolveInstalledPaths(staging);
+      if (stagedPaths == null) {
+        throw const FormatException(
+          'The Mihon proxy server bundle is missing its JRE or server JAR.',
+        );
+      }
+      await makeExecutable(stagedPaths.jrePath);
+
+      if (await installDirectory.exists()) {
+        await installDirectory.rename(backup.path);
+        backedUpLiveInstall = true;
+      }
+      await staging.rename(installDirectory.path);
+
+      final installed = await _resolveInstalledPaths(installDirectory);
+      if (installed == null) {
+        throw const FileSystemException(
+          'The installed Mihon proxy server could not be verified.',
+        );
+      }
+      if (await backup.exists()) {
+        try {
+          await backup.delete(recursive: true);
+        } catch (_) {
+          // A later launch removes this stale backup after verifying live.
+        }
+      }
+      return installed;
+    } catch (_) {
+      if (backedUpLiveInstall && await backup.exists()) {
+        if (await installDirectory.exists()) {
+          await installDirectory.delete(recursive: true);
+        }
+        await backup.rename(installDirectory.path);
+      }
+      rethrow;
+    } finally {
+      if (await download.exists()) await download.delete();
+      if (await staging.exists()) await staging.delete(recursive: true);
+    }
+  }
+
+  Future<void> _recoverInterruptedInstall(Directory installDirectory) async {
+    final download = File('${installDirectory.path}.download');
+    final staging = Directory('${installDirectory.path}.installing');
+    final backup = Directory('${installDirectory.path}.previous');
+
+    if (await download.exists()) await download.delete();
+    if (await staging.exists()) await staging.delete(recursive: true);
+    if (!await backup.exists()) return;
+
+    final live = await _resolveInstalledPaths(installDirectory);
+    if (live != null) {
+      await backup.delete(recursive: true);
+      return;
+    }
+
+    final previous = await _resolveInstalledPaths(backup);
+    if (previous != null || !await installDirectory.exists()) {
+      if (await installDirectory.exists()) {
+        await installDirectory.delete(recursive: true);
+      }
+      await backup.rename(installDirectory.path);
+      return;
+    }
+
+    await backup.delete(recursive: true);
+  }
+
+  Future<_AutoInstallRelease> _fetchRelease() async {
+    final response = await client
+        .get(
+          Uri.parse(extensionServerReleaseApiUrl),
+          headers: const {'Accept': 'application/vnd.github+json'},
+        )
+        .timeout(requestTimeout);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to check Mihon proxy server releases '
+        '(${response.statusCode}).',
+        uri: Uri.parse(extensionServerReleaseApiUrl),
+      );
+    }
+
+    final releases = jsonDecode(response.body) as List<dynamic>;
+    for (final item in releases) {
+      final release = item as Map<String, dynamic>;
+      if ((release['draft'] as bool? ?? false) ||
+          (release['prerelease'] as bool? ?? false)) {
+        continue;
+      }
+      final assets = release['assets'] as List<dynamic>? ?? const [];
+      for (final item in assets) {
+        final asset = item as Map<String, dynamic>;
+        if (asset['name'] != assetName) continue;
+
+        final size = asset['size'] as int?;
+        final digest = asset['digest'] as String?;
+        final downloadUrl = asset['browser_download_url'] as String?;
+        if (size == null || size <= 0 || size > maximumDownloadBytes) {
+          throw FormatException('Invalid release size for $assetName.');
+        }
+        if (digest == null ||
+            !RegExp(r'^sha256:[0-9a-fA-F]{64}$').hasMatch(digest)) {
+          throw FormatException('Missing SHA-256 digest for $assetName.');
+        }
+        final uri = downloadUrl == null ? null : Uri.tryParse(downloadUrl);
+        if (!_isTrustedReleaseUri(uri)) {
+          throw FormatException('Untrusted release URL for $assetName.');
+        }
+        return _AutoInstallRelease(
+          downloadUri: uri!,
+          expectedBytes: size,
+          expectedSha256: digest.substring('sha256:'.length).toLowerCase(),
+        );
+      }
+    }
+    throw StateError(
+      'No stable Mihon proxy server release provides $assetName.',
+    );
+  }
+
+  bool _isTrustedReleaseUri(Uri? uri) {
+    if (uri == null || uri.scheme != 'https' || uri.host != 'github.com') {
+      return false;
+    }
+    return uri.path.startsWith('/1Selxo/M-Extension-Server/releases/download/');
+  }
+
+  Future<void> _downloadBundle(
+    _AutoInstallRelease release,
+    File destination,
+  ) async {
+    final response = await client
+        .send(http.Request('GET', release.downloadUri))
+        .timeout(requestTimeout);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final subscription = response.stream.listen(null);
+      await subscription.cancel();
+      throw HttpException(
+        'Failed to download the Mihon proxy server bundle '
+        '(${response.statusCode}).',
+        uri: release.downloadUri,
+      );
+    }
+    final contentLength = response.contentLength;
+    if (contentLength != null && contentLength != release.expectedBytes) {
+      final subscription = response.stream.listen(null);
+      await subscription.cancel();
+      throw const FormatException(
+        'The Mihon proxy server download size did not match its release.',
+      );
+    }
+
+    var received = 0;
+    final output = destination.openWrite();
+    try {
+      await for (final chunk in response.stream.timeout(requestTimeout)) {
+        received += chunk.length;
+        if (received > release.expectedBytes ||
+            received > maximumDownloadBytes) {
+          throw const FormatException(
+            'The Mihon proxy server download exceeded its release size.',
+          );
+        }
+        output.add(chunk);
+      }
+    } finally {
+      await output.close();
+    }
+    if (received != release.expectedBytes) {
+      throw const FormatException(
+        'The Mihon proxy server download was incomplete.',
+      );
+    }
+
+    final actualDigest = await sha256.bind(destination.openRead()).first;
+    if (actualDigest.toString() != release.expectedSha256) {
+      throw const FormatException(
+        'The Mihon proxy server download failed SHA-256 verification.',
+      );
+    }
+  }
+
+  Future<void> _extractArchive(File archiveFile, Directory destination) async {
+    await _validateCentralDirectory(archiveFile);
+    final input = InputFileStream(archiveFile.path);
+    try {
+      final archive = ZipDecoder().decodeStream(input, verify: true);
+      if (archive.length > maximumArchiveEntries) {
+        throw const FormatException(
+          'The Mihon proxy server bundle contains too many files.',
+        );
+      }
+      final budget = _ExtractionBudget(maximumExtractedBytes);
+      for (final entry in archive) {
+        if (entry.size > budget.remaining) {
+          throw const FormatException(
+            'The Mihon proxy server bundle is too large when extracted.',
+          );
+        }
+        await _extractEntry(entry, destination, budget);
+      }
+    } finally {
+      input.closeSync();
+    }
+  }
+
+  Future<void> _validateCentralDirectory(File archiveFile) async {
+    final length = await archiveFile.length();
+    const maximumTailLength = 65535 + 22;
+    final tailLength = length < maximumTailLength ? length : maximumTailLength;
+    final handle = await archiveFile.open();
+    late final List<int> tail;
+    try {
+      await handle.setPosition(length - tailLength);
+      tail = await handle.read(tailLength);
+    } finally {
+      await handle.close();
+    }
+
+    for (var index = tail.length - 22; index >= 0; index--) {
+      if (tail[index] != 0x50 ||
+          tail[index + 1] != 0x4b ||
+          tail[index + 2] != 0x05 ||
+          tail[index + 3] != 0x06) {
+        continue;
+      }
+      final commentLength = _readUint16LittleEndian(tail, index + 20);
+      if (index + 22 + commentLength != tail.length) continue;
+
+      final diskNumber = _readUint16LittleEndian(tail, index + 4);
+      final centralDirectoryDisk = _readUint16LittleEndian(tail, index + 6);
+      final entriesOnDisk = _readUint16LittleEndian(tail, index + 8);
+      final totalEntries = _readUint16LittleEndian(tail, index + 10);
+      final centralDirectorySize = _readUint32LittleEndian(tail, index + 12);
+      final centralDirectoryOffset = _readUint32LittleEndian(tail, index + 16);
+      final hasZip64Locator =
+          index >= 20 &&
+          _readUint32LittleEndian(tail, index - 20) == 0x07064b50;
+      if (diskNumber != 0 ||
+          centralDirectoryDisk != 0 ||
+          entriesOnDisk != totalEntries ||
+          hasZip64Locator ||
+          totalEntries == 0xffff ||
+          centralDirectorySize == 0xffffffff ||
+          centralDirectoryOffset == 0xffffffff) {
+        throw const FormatException(
+          'Unsupported ZIP structure in Mihon proxy server bundle.',
+        );
+      }
+      if (totalEntries > maximumArchiveEntries) {
+        throw const FormatException(
+          'The Mihon proxy server bundle contains too many files.',
+        );
+      }
+      final endOfCentralDirectoryOffset = length - tailLength + index;
+      if (centralDirectoryOffset + centralDirectorySize !=
+          endOfCentralDirectoryOffset) {
+        throw const FormatException(
+          'Invalid ZIP directory in Mihon proxy server bundle.',
+        );
+      }
+      await _validateCentralDirectoryEntries(
+        archiveFile,
+        offset: centralDirectoryOffset,
+        size: centralDirectorySize,
+        expectedEntries: totalEntries,
+      );
+      return;
+    }
+    throw const FormatException(
+      'Missing ZIP directory in Mihon proxy server bundle.',
+    );
+  }
+
+  Future<void> _validateCentralDirectoryEntries(
+    File archiveFile, {
+    required int offset,
+    required int size,
+    required int expectedEntries,
+  }) async {
+    final handle = await archiveFile.open();
+    var consumedBytes = 0;
+    var actualEntries = 0;
+    try {
+      await handle.setPosition(offset);
+      while (consumedBytes < size) {
+        final header = await handle.read(46);
+        if (header.length != 46 ||
+            _readUint32LittleEndian(header, 0) != 0x02014b50) {
+          throw const FormatException(
+            'Invalid ZIP entry directory in Mihon proxy server bundle.',
+          );
+        }
+        actualEntries++;
+        if (actualEntries > maximumArchiveEntries) {
+          throw const FormatException(
+            'The Mihon proxy server bundle contains too many files.',
+          );
+        }
+
+        final versionMadeBy = _readUint16LittleEndian(header, 4);
+        final externalAttributes = _readUint32LittleEndian(header, 38);
+        final unixMode = externalAttributes >> 16;
+        if ((versionMadeBy >> 8) == 3 && (unixMode & 0xf000) == 0xa000) {
+          throw const FormatException(
+            'Symbolic links are not supported in Mihon proxy server bundles.',
+          );
+        }
+
+        final variableLength =
+            _readUint16LittleEndian(header, 28) +
+            _readUint16LittleEndian(header, 30) +
+            _readUint16LittleEndian(header, 32);
+        consumedBytes += 46 + variableLength;
+        if (consumedBytes > size) {
+          throw const FormatException(
+            'Invalid ZIP entry directory in Mihon proxy server bundle.',
+          );
+        }
+        await handle.setPosition(offset + consumedBytes);
+      }
+    } finally {
+      await handle.close();
+    }
+    if (consumedBytes != size || actualEntries != expectedEntries) {
+      throw const FormatException(
+        'Inconsistent ZIP entry count in Mihon proxy server bundle.',
+      );
+    }
+  }
+
+  Future<void> _extractEntry(
+    ArchiveFile entry,
+    Directory destination,
+    _ExtractionBudget budget,
+  ) async {
+    final outputPath = path.normalize(path.join(destination.path, entry.name));
+    if (outputPath == destination.path ||
+        !path.isWithin(destination.path, outputPath)) {
+      throw FormatException('Unsafe path in Mihon proxy server bundle.');
+    }
+
+    if (entry.isSymbolicLink) {
+      throw const FormatException(
+        'Symbolic links are not supported in Mihon proxy server bundles.',
+      );
+    }
+    if (entry.isDirectory) {
+      await Directory(outputPath).create(recursive: true);
+      return;
+    }
+
+    await File(outputPath).parent.create(recursive: true);
+    final boundedOutput = _BoundedOutputStream(
+      OutputFileStream(outputPath),
+      budget,
+    );
+    try {
+      entry.writeContent(boundedOutput);
+    } finally {
+      await boundedOutput.close();
+    }
+  }
+
+  Future<SystemExtensionServerPaths?> _resolveInstalledPaths(
+    Directory directory,
+  ) async {
+    if (!await directory.exists()) return null;
+    final jrePath = await findExtensionServerJavaExecutable(directory);
+    final jarPath = await findExtensionServerJar(directory);
+    if (jrePath == null || jarPath == null) return null;
+    return SystemExtensionServerPaths(jrePath: jrePath, jarPath: jarPath);
+  }
+
+  static Future<void> _makeExecutable(String filePath) async {
+    if (Platform.isWindows) return;
+    final result = await Process.run('chmod', ['+x', filePath]);
+    if (result.exitCode != 0) {
+      throw ProcessException(
+        'chmod',
+        ['+x', filePath],
+        result.stderr.toString(),
+        result.exitCode,
+      );
+    }
+  }
+}
+
+class _AutoInstallRelease {
+  final Uri downloadUri;
+  final int expectedBytes;
+  final String expectedSha256;
+
+  const _AutoInstallRelease({
+    required this.downloadUri,
+    required this.expectedBytes,
+    required this.expectedSha256,
+  });
+}
+
+int _readUint16LittleEndian(List<int> bytes, int offset) =>
+    bytes[offset] | (bytes[offset + 1] << 8);
+
+int _readUint32LittleEndian(List<int> bytes, int offset) =>
+    bytes[offset] |
+    (bytes[offset + 1] << 8) |
+    (bytes[offset + 2] << 16) |
+    (bytes[offset + 3] << 24);
+
+class _ExtractionBudget {
+  final int maximumBytes;
+  int writtenBytes = 0;
+
+  _ExtractionBudget(this.maximumBytes);
+
+  int get remaining => maximumBytes - writtenBytes;
+
+  void reserve(int byteCount) {
+    if (byteCount < 0 || byteCount > remaining) {
+      throw const FormatException(
+        'The Mihon proxy server bundle is too large when extracted.',
+      );
+    }
+    writtenBytes += byteCount;
+  }
+}
+
+class _BoundedOutputStream extends OutputStream {
+  static const _copyChunkSize = 1024 * 1024;
+
+  final OutputStream delegate;
+  final _ExtractionBudget budget;
+
+  _BoundedOutputStream(this.delegate, this.budget)
+    : super(byteOrder: delegate.byteOrder);
+
+  @override
+  int get length => delegate.length;
+
+  @override
+  bool get isOpen => delegate.isOpen;
+
+  @override
+  void open() => delegate.open();
+
+  @override
+  Future<void> close() => delegate.close();
+
+  @override
+  void closeSync() => delegate.closeSync();
+
+  @override
+  void clear() => delegate.clear();
+
+  @override
+  void flush() => delegate.flush();
+
+  @override
+  void writeByte(int value) {
+    budget.reserve(1);
+    delegate.writeByte(value);
+  }
+
+  @override
+  void writeBytes(List<int> bytes, {int? length}) {
+    final byteCount = length ?? bytes.length;
+    budget.reserve(byteCount);
+    delegate.writeBytes(bytes, length: length);
+  }
+
+  @override
+  void writeStream(InputStream stream) {
+    while (!stream.isEOS) {
+      final chunkLength = stream.length < _copyChunkSize
+          ? stream.length
+          : _copyChunkSize;
+      if (chunkLength <= 0) break;
+      writeBytes(stream.readBytes(chunkLength).toUint8List());
+    }
+  }
+
+  @override
+  Uint8List subset(int start, [int? end]) => delegate.subset(start, end);
+}

--- a/lib/services/m_extension_server.dart
+++ b/lib/services/m_extension_server.dart
@@ -13,6 +13,8 @@ import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/modules/more/settings/browse/extension_server/extension_server_utils.dart';
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
+import 'package:mangayomi/providers/storage_provider.dart';
+import 'package:mangayomi/services/extension_server_auto_installer.dart';
 import 'package:mangayomi/utils/log/logger.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:path/path.dart' as path;
@@ -357,25 +359,54 @@ class MExtensionServerPlatform {
       var serverJarPath = settings?.extensionServerPath ?? '';
       if (isDesktop &&
           (!await _isFile(jrePath) || !await _isFile(serverJarPath))) {
-        // Nothing configured (or the configured files went away). A distro
-        // package may have installed the server system-wide, in which case
-        // adopt it instead of making the user pick the folder by hand.
-        final system = await findSystemExtensionServer();
-        if (system == null) {
+        // Prefer a distro-managed server, then install the matching desktop
+        // bundle into app storage. Failures persist no completion marker, so
+        // the next launch remains eligible to try again.
+        http.Client? installerClient;
+        try {
+          final resolved = await resolveDesktopExtensionServerPaths(
+            configuredJrePath: jrePath,
+            configuredJarPath: serverJarPath,
+            findSystemInstall: findSystemExtensionServer,
+            autoInstall: () async {
+              final assetName = extensionServerAssetNameForCurrentPlatform();
+              if (assetName == null) {
+                throw UnsupportedError(
+                  'No Mihon proxy server bundle supports this desktop.',
+                );
+              }
+              final installDirectory = await StorageProvider()
+                  .getExtensionServerDirectory();
+              if (installDirectory == null) {
+                throw StateError(
+                  'Could not resolve the Mihon proxy server install directory.',
+                );
+              }
+              installerClient = http.Client();
+              return ExtensionServerAutoInstaller(
+                client: installerClient!,
+                assetName: assetName,
+              ).ensureInstalled(installDirectory);
+            },
+          );
+          if (_isCancelled(generation)) return;
+          jrePath = resolved.jrePath;
+          serverJarPath = resolved.jarPath;
+          _persistResolvedServerPaths(jrePath, serverJarPath);
           _log(
-            'Mihon bridge was not started because the configured JRE or JAR '
-            'does not exist. JRE: "$jrePath", JAR: "$serverJarPath".',
-            level: LogLevel.error,
+            'Resolved the desktop Mihon proxy server at '
+            '"${path.dirname(serverJarPath)}".',
+          );
+        } catch (error, stackTrace) {
+          _log(
+            'Automatic Mihon proxy server setup failed; Mangatan will retry '
+            'on the next launch: $error\n$stackTrace',
+            level: LogLevel.warning,
           );
           return;
+        } finally {
+          installerClient?.close();
         }
-        jrePath = system.jrePath;
-        serverJarPath = system.jarPath;
-        _log(
-          'Adopted the package-managed Mihon extension server at '
-          '"${path.dirname(serverJarPath)}".',
-        );
-        _persistResolvedServerPaths(jrePath, serverJarPath);
       }
 
       if (Platform.isLinux) {

--- a/test/modules/more/settings/browse/extension_server_discovery_test.dart
+++ b/test/modules/more/settings/browse/extension_server_discovery_test.dart
@@ -250,13 +250,23 @@ void main() {
       );
       expect(
         serviceSource,
-        contains('final system = await findSystemExtensionServer();'),
-        reason: 'an unconfigured desktop must adopt a distro install',
+        contains('findSystemInstall: findSystemExtensionServer,'),
+        reason: 'an unconfigured desktop must adopt a distro install first',
+      );
+      expect(
+        serviceSource,
+        contains('.ensureInstalled(installDirectory)'),
+        reason: 'a desktop without packaged files must install its own bundle',
+      );
+      expect(
+        serviceSource,
+        contains('Mangatan will retry \'\n            \'on the next launch'),
+        reason: 'an offline first launch must not suppress the next attempt',
       );
       expect(
         serviceSource,
         contains('_persistResolvedServerPaths(jrePath, serverJarPath);'),
-        reason: 'the Settings screen must reflect the adopted paths',
+        reason: 'the Settings screen must reflect the resolved paths',
       );
     });
   });

--- a/test/services/extension_server_auto_installer_test.dart
+++ b/test/services/extension_server_auto_installer_test.dart
@@ -1,0 +1,425 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mangayomi/modules/more/settings/browse/extension_server/extension_server_utils.dart';
+import 'package:mangayomi/services/extension_server_auto_installer.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  group('desktop extension server automatic installer', () {
+    late Directory temp;
+    const assetName = 'linux-x64-bundle.zip';
+    final bundle = _bundleBytes();
+
+    setUp(() async {
+      temp = await Directory.systemTemp.createTemp('mangatan-auto-server-');
+    });
+
+    tearDown(() async {
+      if (await temp.exists()) await temp.delete(recursive: true);
+    });
+
+    test('installs and validates the matching release bundle', () async {
+      final installer = ExtensionServerAutoInstaller(
+        client: _releaseClient(assetName: assetName, bundle: bundle),
+        assetName: assetName,
+        makeExecutable: (_) async {},
+      );
+      final installDirectory = Directory(path.join(temp.path, 'server'));
+
+      final installed = await installer.ensureInstalled(installDirectory);
+
+      expect(await File(installed.jrePath).readAsString(), 'test-java');
+      expect(await File(installed.jarPath).readAsString(), 'test-jar');
+      expect(File('${installDirectory.path}.download').existsSync(), isFalse);
+      expect(
+        Directory('${installDirectory.path}.installing').existsSync(),
+        isFalse,
+      );
+      expect(
+        Directory('${installDirectory.path}.previous').existsSync(),
+        isFalse,
+      );
+    });
+
+    test(
+      'an offline first launch remains eligible for the next launch',
+      () async {
+        var online = false;
+        var releaseAttempts = 0;
+        final client = MockClient((request) async {
+          if (request.url.toString() == extensionServerReleaseApiUrl) {
+            releaseAttempts++;
+            if (!online) throw const SocketException('offline');
+            return _releaseResponse(assetName: assetName, bundle: bundle);
+          }
+          return http.Response.bytes(bundle, 200);
+        });
+        final installer = ExtensionServerAutoInstaller(
+          client: client,
+          assetName: assetName,
+          makeExecutable: (_) async {},
+        );
+        final installDirectory = Directory(path.join(temp.path, 'server'));
+
+        await expectLater(
+          installer.ensureInstalled(installDirectory),
+          throwsA(isA<SocketException>()),
+        );
+        online = true;
+        final installed = await installer.ensureInstalled(installDirectory);
+
+        expect(releaseAttempts, 2);
+        expect(File(installed.jarPath).existsSync(), isTrue);
+      },
+    );
+
+    test(
+      'cleans interrupted artifacts before an offline release lookup',
+      () async {
+        final installDirectory = Directory(path.join(temp.path, 'server'));
+        await File('${installDirectory.path}.download').create(recursive: true);
+        await Directory(
+          '${installDirectory.path}.installing',
+        ).create(recursive: true);
+        final installer = ExtensionServerAutoInstaller(
+          client: MockClient(
+            (_) async => throw const SocketException('offline'),
+          ),
+          assetName: assetName,
+          makeExecutable: (_) async {},
+        );
+
+        await expectLater(
+          installer.ensureInstalled(installDirectory),
+          throwsA(isA<SocketException>()),
+        );
+
+        expect(File('${installDirectory.path}.download').existsSync(), isFalse);
+        expect(
+          Directory('${installDirectory.path}.installing').existsSync(),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'a digest failure is not promoted and can retry successfully',
+      () async {
+        var validDigest = false;
+        final client = MockClient((request) async {
+          if (request.url.toString() == extensionServerReleaseApiUrl) {
+            return _releaseResponse(
+              assetName: assetName,
+              bundle: bundle,
+              digestOverride: validDigest ? null : 'sha256:${'0' * 64}',
+            );
+          }
+          return http.Response.bytes(bundle, 200);
+        });
+        final installer = ExtensionServerAutoInstaller(
+          client: client,
+          assetName: assetName,
+          makeExecutable: (_) async {},
+        );
+        final installDirectory = Directory(path.join(temp.path, 'server'));
+
+        await expectLater(
+          installer.ensureInstalled(installDirectory),
+          throwsA(isA<FormatException>()),
+        );
+        expect(installDirectory.existsSync(), isFalse);
+        validDigest = true;
+
+        final installed = await installer.ensureInstalled(installDirectory);
+        expect(File(installed.jarPath).existsSync(), isTrue);
+      },
+    );
+
+    test('rejects archive paths that escape the install directory', () async {
+      final unsafeBundle = _unsafeBundleBytes();
+      final installer = ExtensionServerAutoInstaller(
+        client: _releaseClient(assetName: assetName, bundle: unsafeBundle),
+        assetName: assetName,
+        makeExecutable: (_) async {},
+      );
+      final installDirectory = Directory(path.join(temp.path, 'server'));
+
+      await expectLater(
+        installer.ensureInstalled(installDirectory),
+        throwsA(isA<FormatException>()),
+      );
+
+      expect(File(path.join(temp.path, 'escaped.txt')).existsSync(), isFalse);
+      expect(installDirectory.existsSync(), isFalse);
+    });
+
+    test('rejects bundles whose extracted size exceeds the limit', () async {
+      final installer = ExtensionServerAutoInstaller(
+        client: _releaseClient(assetName: assetName, bundle: bundle),
+        assetName: assetName,
+        makeExecutable: (_) async {},
+        maximumExtractedBytes: 1,
+      );
+      final installDirectory = Directory(path.join(temp.path, 'server'));
+
+      await expectLater(
+        installer.ensureInstalled(installDirectory),
+        throwsA(isA<FormatException>()),
+      );
+      expect(installDirectory.existsSync(), isFalse);
+    });
+
+    test('bounds actual decompressed bytes, not forged ZIP metadata', () async {
+      final forgedBundle = _forgedSizeBundleBytes();
+      final installer = ExtensionServerAutoInstaller(
+        client: _releaseClient(assetName: assetName, bundle: forgedBundle),
+        assetName: assetName,
+        makeExecutable: (_) async {},
+        maximumExtractedBytes: 100,
+      );
+      final installDirectory = Directory(path.join(temp.path, 'server'));
+
+      await expectLater(
+        installer.ensureInstalled(installDirectory),
+        throwsA(isA<FormatException>()),
+      );
+      expect(installDirectory.existsSync(), isFalse);
+    });
+
+    test(
+      'rejects a forged central-directory entry count before decoding',
+      () async {
+        final forgedBundle = _bundleBytes().toList();
+        _forgeEndOfCentralDirectoryEntryCount(forgedBundle, 1);
+        final installer = ExtensionServerAutoInstaller(
+          client: _releaseClient(assetName: assetName, bundle: forgedBundle),
+          assetName: assetName,
+          makeExecutable: (_) async {},
+        );
+        final installDirectory = Directory(path.join(temp.path, 'server'));
+
+        await expectLater(
+          installer.ensureInstalled(installDirectory),
+          throwsA(isA<FormatException>()),
+        );
+        expect(installDirectory.existsSync(), isFalse);
+      },
+    );
+
+    test(
+      'recovers the prior install after an interrupted atomic swap',
+      () async {
+        final installDirectory = Directory(path.join(temp.path, 'server'));
+        final previous = Directory('${installDirectory.path}.previous');
+        await _writeInstall(previous);
+        await Directory(
+          '${installDirectory.path}.installing',
+        ).create(recursive: true);
+        final installer = ExtensionServerAutoInstaller(
+          client: MockClient(
+            (_) async => throw StateError('must not download'),
+          ),
+          assetName: assetName,
+          makeExecutable: (_) async {},
+        );
+
+        final installed = await installer.ensureInstalled(installDirectory);
+
+        expect(File(installed.jarPath).existsSync(), isTrue);
+        expect(previous.existsSync(), isFalse);
+        expect(
+          Directory('${installDirectory.path}.installing').existsSync(),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'keeps an existing configured server ahead of discovery and download',
+      () async {
+        final configured = Directory(path.join(temp.path, 'configured'));
+        await _writeInstall(configured);
+        var discoveryCalls = 0;
+        var installCalls = 0;
+
+        final resolved = await resolveDesktopExtensionServerPaths(
+          configuredJrePath: path.join(
+            configured.path,
+            'jre',
+            'jre',
+            'bin',
+            'java',
+          ),
+          configuredJarPath: path.join(
+            configured.path,
+            'MExtensionServer-v1.jar',
+          ),
+          findSystemInstall: () async {
+            discoveryCalls++;
+            return null;
+          },
+          autoInstall: () async {
+            installCalls++;
+            throw StateError('must not install');
+          },
+        );
+
+        expect(resolved.jarPath, endsWith('MExtensionServer-v1.jar'));
+        expect(discoveryCalls, 0);
+        expect(installCalls, 0);
+      },
+    );
+
+    test(
+      'uses automatic installation after package discovery misses',
+      () async {
+        var installCalls = 0;
+        final expected = SystemExtensionServerPaths(
+          jrePath: path.join(temp.path, 'java'),
+          jarPath: path.join(temp.path, 'server.jar'),
+        );
+
+        final resolved = await resolveDesktopExtensionServerPaths(
+          configuredJrePath: '',
+          configuredJarPath: '',
+          findSystemInstall: () async => null,
+          autoInstall: () async {
+            installCalls++;
+            return expected;
+          },
+        );
+
+        expect(resolved.jarPath, expected.jarPath);
+        expect(installCalls, 1);
+      },
+    );
+  });
+}
+
+MockClient _releaseClient({
+  required String assetName,
+  required List<int> bundle,
+}) {
+  return MockClient((request) async {
+    if (request.url.toString() == extensionServerReleaseApiUrl) {
+      return _releaseResponse(assetName: assetName, bundle: bundle);
+    }
+    return http.Response.bytes(bundle, 200);
+  });
+}
+
+http.Response _releaseResponse({
+  required String assetName,
+  required List<int> bundle,
+  String? digestOverride,
+}) {
+  return http.Response(
+    jsonEncode([
+      {
+        'draft': false,
+        'prerelease': false,
+        'assets': [
+          {
+            'name': assetName,
+            'size': bundle.length,
+            'digest': digestOverride ?? 'sha256:${sha256.convert(bundle)}',
+            'browser_download_url':
+                'https://github.com/1Selxo/M-Extension-Server/releases/download/v1/$assetName',
+          },
+        ],
+      },
+    ]),
+    200,
+  );
+}
+
+List<int> _bundleBytes() {
+  final archive = Archive()
+    ..addFile(ArchiveFile.string('MExtensionServer-v1.jar', 'test-jar'))
+    ..addFile(ArchiveFile.string('jre/jre/bin/java', 'test-java'));
+  return ZipEncoder().encode(archive);
+}
+
+List<int> _unsafeBundleBytes() {
+  final archive = Archive()
+    ..addFile(ArchiveFile.string('../escaped.txt', 'escape'))
+    ..addFile(ArchiveFile.string('MExtensionServer-v1.jar', 'test-jar'))
+    ..addFile(ArchiveFile.string('jre/jre/bin/java', 'test-java'));
+  return ZipEncoder().encode(archive);
+}
+
+void _forgeEndOfCentralDirectoryEntryCount(
+  List<int> bytes,
+  int declaredEntries,
+) {
+  for (var index = bytes.length - 22; index >= 0; index--) {
+    if (bytes[index] == 0x50 &&
+        bytes[index + 1] == 0x4b &&
+        bytes[index + 2] == 0x05 &&
+        bytes[index + 3] == 0x06) {
+      bytes[index + 8] = declaredEntries & 0xff;
+      bytes[index + 9] = (declaredEntries >> 8) & 0xff;
+      bytes[index + 10] = declaredEntries & 0xff;
+      bytes[index + 11] = (declaredEntries >> 8) & 0xff;
+      return;
+    }
+  }
+  throw StateError('ZIP end-of-central-directory record not found');
+}
+
+List<int> _forgedSizeBundleBytes() {
+  final large = List<int>.filled(1024 * 1024, 65);
+  final archive = Archive()
+    ..addFile(ArchiveFile('MExtensionServer-v1.jar', large.length, large))
+    ..addFile(ArchiveFile('jre/jre/bin/java', large.length, large));
+  final bytes = ZipEncoder().encode(archive).toList();
+  _forgeCentralDirectorySize(bytes, 'MExtensionServer-v1.jar', 1);
+  _forgeCentralDirectorySize(bytes, 'jre/jre/bin/java', 1);
+  return bytes;
+}
+
+void _forgeCentralDirectorySize(
+  List<int> bytes,
+  String fileName,
+  int declaredSize,
+) {
+  final nameBytes = utf8.encode(fileName);
+  for (var index = 0; index + 46 + nameBytes.length <= bytes.length; index++) {
+    if (bytes[index] != 0x50 ||
+        bytes[index + 1] != 0x4b ||
+        bytes[index + 2] != 0x01 ||
+        bytes[index + 3] != 0x02) {
+      continue;
+    }
+    final nameLength = bytes[index + 28] | (bytes[index + 29] << 8);
+    if (nameLength != nameBytes.length) continue;
+    var matches = true;
+    for (var offset = 0; offset < nameLength; offset++) {
+      if (bytes[index + 46 + offset] != nameBytes[offset]) {
+        matches = false;
+        break;
+      }
+    }
+    if (!matches) continue;
+    for (var byte = 0; byte < 4; byte++) {
+      bytes[index + 24 + byte] = (declaredSize >> (byte * 8)) & 0xff;
+    }
+    return;
+  }
+  throw StateError('ZIP central directory entry not found: $fileName');
+}
+
+Future<void> _writeInstall(Directory root) async {
+  final java = File(path.join(root.path, 'jre', 'jre', 'bin', 'java'));
+  await java.create(recursive: true);
+  await java.writeAsString('test-java');
+  final jar = File(path.join(root.path, 'MExtensionServer-v1.jar'));
+  await jar.create(recursive: true);
+  await jar.writeAsString('test-jar');
+}


### PR DESCRIPTION
## Summary
- automatically install the matching M-Extension-Server desktop bundle when neither configured nor package-managed server files are available
- leave failed/offline attempts unpersisted so startup retries on every later launch until installation succeeds
- verify GitHub's published asset size and SHA-256, bound archive resources, reject unsafe ZIP structures, and atomically promote validated installs with crash recovery
- keep the automatic installer desktop-only; iOS and Android retain their existing bridge behavior

## Testing
- Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 91.0.0 (105.0.0 available)
  analyzer 8.4.1 (14.1.0 available)
  analyzer_buffer 0.1.11 (0.3.3 available)
  app_links 7.2.0 (7.2.1 available)
  app_links_platform_interface 2.0.3 (2.0.4 available)
  build 4.0.6 (4.0.10 available)
  build_config 1.3.0 (1.3.2 available)
  build_daemon 4.1.1 (4.1.3 available)
  build_runner 2.15.0 (2.16.0 available)
  cli_util 0.4.2 (0.5.2 available)
  connectivity_plus 7.2.0 (7.3.1 available)
  cross_file 0.3.5+2 (0.3.5+4 available)
  dart_style 3.1.3 (3.1.12 available)
  device_info_plus 12.4.0 (13.2.0 available)
  device_info_plus_platform_interface 7.0.3 (8.1.0 available)
  extended_image 10.0.1 (10.1.0 available)
! ffi 2.2.0 (overridden)
  ffigen 20.1.1 (21.0.0 available)
  file_picker 11.0.2 (11.0.3 available)
  flutter_riverpod 3.1.0 (3.4.2 available)
  flutter_secure_storage_darwin 0.3.2 (0.4.0 available)
  flutter_secure_storage_platform_interface 2.0.1 (2.0.2 available)
  flutter_secure_storage_windows 4.1.0 (4.2.2 available)
! flutter_web_auth_2 3.1.2-without-v1 from git https://github.com/ThexXTURBOXx/flutter_web_auth_2.git at 48682f in flutter_web_auth_2 (overridden)
  flutter_web_auth_2_platform_interface 3.1.0 (5.0.0 available)
  freezed 3.2.3 (3.2.5 available)
  google_fonts 8.1.0 (8.2.1 available)
  hooks 2.0.2 (2.1.0 available)
! html 0.15.6 (overridden)
  http_interceptor 2.0.0 (3.0.0 available)
  image 4.8.0 (4.9.1 available)
  inno_bundle 0.9.0 (0.11.2 available)
  intl 0.20.2 (0.20.3 available)
  isolate_contactor 4.1.0 (4.2.0 available)
  isolate_manager 4.1.5+1 (6.3.2 available)
  jni 1.0.0 (1.0.3 available)
  jni_flutter 1.0.1 (1.0.2 available)
  local_auth 3.0.1 (3.0.2 available)
  matcher 0.12.19 (0.12.20 available)
  meta 1.18.0 (1.19.0 available)
  mockito 5.6.4 (5.8.0 available)
  native_toolchain_c 0.19.2 (0.19.3 available)
  objective_c 9.4.1 (9.5.0 available)
  package_config 2.2.0 (3.0.0 available)
  package_info_plus 9.0.1 (10.2.1 available)
  package_info_plus_platform_interface 3.2.1 (4.1.0 available)
  permission_handler 12.0.3 (13.0.0 available)
  permission_handler_android 13.0.1 (14.0.0 available)
  permission_handler_apple 9.4.10 (9.5.0 available)
  permission_handler_html 0.1.3+5 (0.1.4+1 available)
  permission_handler_platform_interface 4.3.0 (4.4.0 available)
  permission_handler_windows 0.2.1 (0.2.2 available)
  pointycastle 3.9.1 (4.0.0 available)
  posix 6.5.0 (6.5.2 available)
  protobuf 5.1.0 (6.0.0 available)
  protoc_plugin 23.0.0 (25.0.0 available)
  re_editor 0.9.0 (0.10.0 available)
  record_use 0.6.0 (1.0.0 available)
  riverpod 3.1.0 (3.4.2 available)
  riverpod_analyzer_utils 1.0.0-dev.8 (1.0.0-dev.11 available)
  riverpod_annotation 4.0.0 (4.0.6 available)
  riverpod_generator 4.0.0+1 (4.0.8 available)
  safe_local_storage 2.0.4 (2.0.6 available)
  screen_retriever 0.2.1 (0.2.2 available)
  screen_retriever_linux 0.2.1 (0.2.2 available)
  screen_retriever_macos 0.2.1 (0.2.2 available)
  screen_retriever_platform_interface 0.2.1 (0.2.2 available)
  screen_retriever_windows 0.2.1 (0.2.2 available)
  share_plus 12.0.2 (13.3.0 available)
  share_plus_platform_interface 6.1.0 (7.2.0 available)
  source_gen 4.2.3 (4.2.4 available)
  synchronized 3.4.1 (3.4.1+1 available)
  test 1.31.0 (1.31.2 available)
  test_api 0.7.11 (0.7.13 available)
  test_core 0.6.17 (0.6.19 available)
  uuid 4.5.3 (4.6.0 available)
  vector_math 2.2.0 (2.4.2 available)
  wakelock_plus 1.5.2 (1.7.0 available)
  wakelock_plus_platform_interface 1.5.1 (1.6.0 available)
  win32 5.15.0 (6.3.0 available)
  win32_registry 2.1.0 (3.0.3 available)
  window_manager 0.5.1 (0.5.2 available)
  window_to_front 0.0.4 (1.0.0 available)
  xml 6.6.1 (7.0.1 available)
Got dependencies!
81 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart
00:00 +0: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer installs and validates the matching release bundle
00:00 +1: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer an offline first launch remains eligible for the next launch
00:00 +2: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer cleans interrupted artifacts before an offline release lookup
00:00 +3: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer a digest failure is not promoted and can retry successfully
00:00 +4: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer rejects archive paths that escape the install directory
00:00 +5: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer rejects bundles whose extracted size exceeds the limit
00:00 +6: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer bounds actual decompressed bytes, not forged ZIP metadata
00:00 +7: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer rejects a forged central-directory entry count before decoding
00:00 +8: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer recovers the prior install after an interrupted atomic swap
00:00 +9: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer keeps an existing configured server ahead of discovery and download
00:00 +10: /tmp/mangatan-auto-install-pr/test/services/extension_server_auto_installer_test.dart: desktop extension server automatic installer uses automatic installation after package discovery misses
00:14 +11: /tmp/mangatan-auto-install-pr/test/services/m_extension_server_test.dart: embedded iOS Mihon bridge response accepts a valid loopback port
00:14 +12: /tmp/mangatan-auto-install-pr/test/services/m_extension_server_test.dart: embedded iOS Mihon bridge response constructs the URL when native code only returns a port
00:14 +13: /tmp/mangatan-auto-install-pr/test/services/m_extension_server_test.dart: embedded iOS Mihon bridge response rejects remote, invalid, and mismatched responses
00:14 +14: /tmp/mangatan-auto-install-pr/test/services/m_extension_server_test.dart: keeps the iOS VM outside the app launch image and UI thread
00:15 +15: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: package-managed extension server discovery resolves a JAR and a symlinked java from a packaged layout
00:15 +16: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: package-managed extension server discovery reports the packaged version rather than the fallback
00:15 +17: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: package-managed extension server discovery skips a partially removed package instead of half-adopting it
00:15 +18: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: package-managed extension server discovery falls through to a later candidate directory
00:15 +19: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: package-managed extension server discovery returns null when nothing is installed
00:15 +20: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: managed directory guard recognises the documented system locations
00:15 +21: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: managed directory guard leaves user-chosen directories writable
00:15 +22: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: managed directory guard guards an ancestor of a managed directory
00:15 +23: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: managed directory guard guards a subdirectory of a managed directory
00:15 +24: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: managed directory guard the installer refuses to wipe a package-managed directory
00:15 +25: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: JRE version pre-flight parses the runtime the Arch package depends on
00:15 +26: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: JRE version pre-flight parses a too-old runtime so the launch can be refused
00:15 +27: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: JRE version pre-flight returns null on unparseable output so a probe never blocks
00:15 +28: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: JRE version pre-flight the service refuses to launch an unsupported runtime
00:15 +29: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: Arch packaging contract the app package pulls in the startup dependency
00:15 +30: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: Arch packaging contract the server package installs the layout the app probes
00:15 +31: /tmp/mangatan-auto-install-pr/test/modules/more/settings/browse/extension_server_discovery_test.dart: Arch packaging contract the server package extracts exactly one JAR
00:15 +32: All tests passed! (32 passed)
- Analyzing extension_server_auto_installer.dart, m_extension_server.dart, extension_server_auto_installer_test.dart...
No issues found!
- Formatted 3 files (0 changed) in 0.03 seconds.
- 
- downloaded the current Linux x64 release bundle and completed a real install/extract validation (JAR and Java executable resolved)
- inspected current Linux x64 and macOS arm64 bundles for compatibility with the ZIP preflight (232/235 entries, no symlinks)

## Retry behavior
There is deliberately no one-shot or attempted-install flag. Network, integrity, or extraction failures return without persisting server paths, so the same startup path retries on the next launch.