### PR TITLE
test(mining): guard always-active OCR overlay (issue #50)

### DIFF
--- a/test/services/mining/ocr_overlay_always_active_test.dart
+++ b/test/services/mining/ocr_overlay_always_active_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:mangayomi/services/mining/mining_preferences.dart';
+
+/// Regression guard for issue #50 ("Always active overlay option").
+///
+/// The userscript era required a long-press to *activate* the OCR overlay on
+/// every page. The current rewrite replaces that with a single persistent
+/// preference — [MiningPreferences.getOcrOverlayEnabled] — that:
+///
+///   * defaults to ON, so a fresh install shows the overlay without any
+///     per-page long-press activation, and
+///   * persists the user's choice across reader sessions (box reopen), so the
+///     overlay stays in the state the user last left it — "always active"
+///     until the user explicitly turns it off.
+///
+/// These tests pin both halves of that contract so a future refactor cannot
+/// silently regress to the long-press-to-activate model.
+void main() {
+  late Directory tempDirectory;
+
+  Future<void> resetPreferences() async {
+    if (Hive.isBoxOpen('mining_preferences')) {
+      await Hive.box<dynamic>('mining_preferences').close();
+    }
+    await Hive.deleteBoxFromDisk('mining_preferences');
+  }
+
+  setUpAll(() async {
+    tempDirectory = await Directory.systemTemp.createTemp(
+      'mangatan-ocr-overlay-always-active-',
+    );
+    Hive.init(tempDirectory.path);
+    MiningPreferences.configureStorageDirectory(tempDirectory.path);
+  });
+
+  setUp(resetPreferences);
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (await tempDirectory.exists()) {
+      await tempDirectory.delete(recursive: true);
+    }
+  });
+
+  test(
+    'overlay is active by default on a fresh install (no long-press to activate)',
+    () async {
+      // A fresh install has never written the key. The overlay must already be
+      // active — this is the "always active" default the issue asked for.
+      expect(await MiningPreferences.getOcrOverlayEnabled(), isTrue);
+    },
+  );
+
+  test(
+    'enabling the overlay persists across a reader/session restart',
+    () async {
+      // User turns it off...
+      await MiningPreferences.setOcrOverlayEnabled(false);
+      expect(await MiningPreferences.getOcrOverlayEnabled(), isFalse);
+
+      // ...simulate the app/reader being torn down and rebuilt (box reopen).
+      await Hive.box<dynamic>('mining_preferences').close();
+      expect(await MiningPreferences.getOcrOverlayEnabled(), isFalse);
+
+      // ...user turns it back on; the choice survives another restart.
+      await MiningPreferences.setOcrOverlayEnabled(true);
+      await Hive.box<dynamic>('mining_preferences').close();
+      expect(await MiningPreferences.getOcrOverlayEnabled(), isTrue);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Audit of historical issue #50 — *"[Request | Mobile] Always active overlay option"* — against the current `main` rewrite.

The original request: instead of a per-page long-press to activate the OCR overlay, offer an option for it to always be on.

**Finding: already implemented in the rewrite, but unguarded by tests.** The current app exposes a single persistent preference `MiningPreferences.getOcrOverlayEnabled` (`ocr_overlay_enabled` Hive key) surfaced through `ReaderOcrState.enabled`, which:

- **defaults to ON** — a fresh install shows the overlay with no per-page long-press activation, and
- **persists the user's choice across reader/app sessions** — the overlay stays in whatever state the user last left it ("always active" until they turn it off).

Toggling is via the reader app-bar button, the *"Show OCR in reader"* settings switch, the two-finger tap gesture, and the image-actions dialog — the userscript-era long-press-to-activate model is gone.

Per the audit rules, an already-fixed issue gets a **meaningful regression test**, not a no-op change. This PR adds one that pins both halves of the "always active" contract:

- `overlay is active by default on a fresh install (no long-press to activate)`
- `enabling the overlay persists across a reader/session restart`

## Test plan

- `flutter test test/services/mining/ocr_overlay_always_active_test.dart` → 2 passed.
- Broader `test/services/sync/chimahon_mining_settings_adapter_test.dart` → 8 passed (no regressions).
- `dart format --set-exit-if-changed` clean; `dart analyze` no issues; `git diff --check` clean.
- **Guard proof (mutation):** flipping `getOcrOverlayEnabled` default to `false` and making `setOcrOverlayEnabled` a no-op turns both tests RED (`Expected: true / Actual: <false>`); restoring the production code (zero diff vs HEAD) returns them GREEN.

Test-only; no runtime change, so no pubspec build-number bump per AGENTS.md.

Relates to #50 (do not close — the issue was already closed by the maintainer during the rewrite).