### PR TITLE
fix(reader): stop vertical OCR text clipping in small boxes (#49)

### DIFF
--- a/lib/modules/mining/widgets/reader_ocr_overlay.dart
+++ b/lib/modules/mining/widgets/reader_ocr_overlay.dart
@@ -1507,10 +1507,13 @@ class ReaderOcrController extends ChangeNotifier {
 
   void _paintVerticalText(Canvas canvas, Rect rect, String text, double alpha) {
     final rowHeight = rect.height / math.max(1, text.length);
-    final fontSize = math.max(
-      8.0,
-      math.min(rect.width * 0.82, rowHeight * 0.95),
+    final fontSize = readerOcrVerticalFontSize(
+      boxWidth: rect.width,
+      boxHeight: rect.height,
+      glyphCount: text.length,
     );
+    canvas.save();
+    canvas.clipRect(rect);
     for (var index = 0; index < text.length; index++) {
       final painter = TextPainter(
         maxLines: 1,
@@ -1533,6 +1536,7 @@ class ReaderOcrController extends ChangeNotifier {
         ),
       );
     }
+    canvas.restore();
   }
 
   Rect? _lineHighlightFor({
@@ -1766,6 +1770,36 @@ double readerOcrHorizontalTextScale({
   );
   if (scale.isNaN || scale <= 0) return 1.0;
   return math.min(1.0, scale);
+}
+
+/// Font size for a vertical (top-to-bottom) OCR line so its glyph column
+/// always fits inside its box.
+///
+/// Fixes issue #49: the previous implementation applied a hard `8.0` px floor
+/// after fitting to the box, so on small boxes (common on mobile) the stacked
+/// glyphs — `fontSize * glyphCount` — exceeded the box height and clipped off
+/// the bottom characters. The size now tracks the smaller of the per-row height
+/// and the box width and is clamped so the whole column stays inside the box in
+/// both dimensions; a floor is only applied when it does not force overflow.
+@visibleForTesting
+double readerOcrVerticalFontSize({
+  required double boxWidth,
+  required double boxHeight,
+  required int glyphCount,
+}) {
+  if (glyphCount <= 0 || boxWidth <= 0 || boxHeight <= 0) return 0.0;
+  final rowHeight = boxHeight / glyphCount;
+  // Track the tighter of the two axes: a glyph must fit both the per-character
+  // row height and the box width.
+  var fontSize = math.min(boxWidth * 0.95, rowHeight * 0.95);
+  // Only raise toward a comfortable minimum when doing so still keeps the whole
+  // column inside the box; never let the floor reintroduce clipping.
+  const desiredMin = 8.0;
+  final maxFit = math.min(rowHeight, boxWidth);
+  if (fontSize < desiredMin) {
+    fontSize = math.min(desiredMin, maxFit);
+  }
+  return fontSize;
 }
 
 @visibleForTesting

--- a/test/modules/mining/reader_ocr_overlay_geometry_test.dart
+++ b/test/modules/mining/reader_ocr_overlay_geometry_test.dart
@@ -307,6 +307,61 @@ void main() {
     );
   });
 
+  group('vertical OCR text never clips its box', () {
+    test('a small mobile box keeps the glyph column inside the box height', () {
+      // A tall, narrow vertical block on a phone: 9 characters in a box only
+      // 40px high. The legacy 8.0px font floor forced 8*9 = 72px of glyphs
+      // into a 40px box, clipping the bottom characters off screen.
+      const box = Rect.fromLTWH(0, 0, 18, 40);
+      const glyphCount = 9;
+
+      final fontSize = readerOcrVerticalFontSize(
+        boxWidth: box.width,
+        boxHeight: box.height,
+        glyphCount: glyphCount,
+      );
+
+      // Stacked glyphs must fit the box height, otherwise text clips.
+      expect(
+        fontSize * glyphCount,
+        lessThanOrEqualTo(box.height + 0.001),
+        reason: 'stacked glyph column must not exceed the box height',
+      );
+      // And a single glyph must fit the box width.
+      expect(
+        fontSize,
+        lessThanOrEqualTo(box.width + 0.001),
+        reason: 'a glyph must not exceed the box width',
+      );
+    });
+
+    test('a roomy box still scales the font up to fill the rows', () {
+      const box = Rect.fromLTWH(0, 0, 60, 400);
+      const glyphCount = 8;
+
+      final fontSize = readerOcrVerticalFontSize(
+        boxWidth: box.width,
+        boxHeight: box.height,
+        glyphCount: glyphCount,
+      );
+
+      // rowHeight = 400/8 = 50; width 60. The font should track the smaller
+      // dimension and stay well above the old 8px floor, but never overflow.
+      expect(fontSize, greaterThan(8.0));
+      expect(fontSize * glyphCount, lessThanOrEqualTo(box.height + 0.001));
+      expect(fontSize, lessThanOrEqualTo(box.width + 0.001));
+    });
+
+    test('an empty block yields a safe non-negative font size', () {
+      final fontSize = readerOcrVerticalFontSize(
+        boxWidth: 10,
+        boxHeight: 10,
+        glyphCount: 0,
+      );
+      expect(fontSize, greaterThanOrEqualTo(0.0));
+    });
+  });
+
   test('matches either Shift key on key down and key up', () {
     for (final keys in [
       (PhysicalKeyboardKey.shiftLeft, LogicalKeyboardKey.shiftLeft),


### PR DESCRIPTION
## Summary
Addresses the text-clipping report in issue #49 ("Text Clipping | Better font size/box support", especially on mobile).

The vertical OCR overlay painter (`_paintVerticalText` in `lib/modules/mining/widgets/reader_ocr_overlay.dart`) sized each glyph as:

```dart
final fontSize = math.max(8.0, math.min(rect.width * 0.82, rowHeight * 0.95));
```

The hard `8.0`px floor was applied **after** the fit, so it overrode it. On a small box (common on mobile) where `rowHeight * 0.95 < 8.0`, the stacked glyph column — `fontSize * glyphCount` — exceeded the box height and the bottom characters clipped off. The vertical painter also never clipped to its rect (unlike the horizontal path), so any overflow spilled visibly.

## Fix
- Extract `readerOcrVerticalFontSize` as a pure `@visibleForTesting` helper.
- Size tracks the tighter of the per-row height and box width, and the 8px minimum is only applied when it still keeps the **whole column** inside the box in both dimensions — it can never reintroduce overflow.
- Clip the vertical painter to its rect, matching `_paintHorizontalText`.

## Test Plan
- Added a mutation-verified regression test group in `test/modules/mining/reader_ocr_overlay_geometry_test.dart`:
  - a mobile-scale box (18×40, 9 glyphs) keeps `fontSize * glyphCount` inside the box height and each glyph inside the width;
  - a roomy box still scales the font well above 8px without overflowing;
  - an empty block yields a safe non-negative size.
- **Falsification:** temporarily restoring the old `math.max(8.0, min(width*0.82, ...))` form makes the mobile test go RED with `Actual: <72.0>` (8px × 9) vs the 40px box; restoring the fix returns GREEN with the production file at zero diff vs the committed change.

## Verification (Linux host)
- `dart format --output=none --set-exit-if-changed` on both files: clean (0 changed)
- `flutter analyze` on both files: No issues found
- `flutter test test/modules/mining/reader_ocr_overlay_geometry_test.dart`: 14/14 passed
- `git diff --check`: clean

No pubspec build-number bump: this is a Linux-verified code/test change, not a device-testable IPA artifact per AGENTS.md.

Links #49 (historical issue, already closed — not claiming to close it).