### PR TITLE
docs: add per-platform desktop download steps (issue #56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,16 @@ Features include:
 
 ## Download
 
-Get Mangatan from the [releases page](https://github.com/1Selxo/Mangatan/releases).
+Get Mangatan from the [releases page](https://github.com/1Selxo/Mangatan/releases),
+then download the asset that matches your platform:
+
+- **Windows** — `Mangatan-<version>-windows.exe` (installer) or
+  `Mangatan-<version>-windows.zip` (portable).
+- **macOS** — `Mangatan-<version>-macos-arm64.dmg` (Apple Silicon).
+- **Linux** — `Mangatan-<version>-linux-x86_64.tar.gz`.
+
+See the [desktop install guide](docs/desktop_install.md) for the full
+download-and-run steps on each platform.
 
 ### Android
 

--- a/docs/desktop_install.md
+++ b/docs/desktop_install.md
@@ -1,0 +1,49 @@
+# Desktop install guide
+
+Mangatan ships prebuilt desktop apps on the
+[releases page](https://github.com/1Selxo/Mangatan/releases). Download the
+asset that matches your operating system, then follow the run step below. Each
+platform's release also includes a `SHA256SUMS` file you can use to verify the
+download.
+
+## Windows
+
+1. On the [latest release](https://github.com/1Selxo/Mangatan/releases/latest),
+   download **either**:
+   - `Mangatan-<version>-windows.exe` — the installer (recommended), or
+   - `Mangatan-<version>-windows.zip` — a portable build.
+2. Installer: run the `.exe` and follow the prompts.
+   Portable: extract the `.zip` and run `mangayomi.exe` from the extracted
+   folder.
+
+## macOS
+
+1. Download `Mangatan-<version>-macos-arm64.dmg` (Apple Silicon).
+2. Open the `.dmg` and drag **Mangatan** into your **Applications** folder.
+3. The build is unsigned, so the first launch is blocked by Gatekeeper.
+   Right-click **Mangatan** → **Open**, then confirm **Open** in the dialog (or
+   allow it under **System Settings → Privacy & Security**).
+
+## Linux
+
+1. Download `Mangatan-<version>-linux-x86_64.tar.gz`.
+2. Extract it, then run the `mangayomi` binary from the extracted folder:
+
+   ```sh
+   tar -xzf Mangatan-<version>-linux-x86_64.tar.gz
+   cd Mangatan-<version>-linux-x86_64
+   ./mangayomi
+   ```
+
+   Arch Linux users can instead install the `mangatan-bin` package from the AUR
+   (see [`packaging/arch/README.md`](../packaging/arch/README.md)).
+
+## Android
+
+The Android version lives in a separate project — see
+[Chimahon](https://github.com/sohilsayed/chimahon).
+
+## iOS
+
+iOS is sideloaded from the unsigned IPA. See the **iOS Sideloading Sources**
+section of the [README](../README.md).

--- a/test/docs/desktop_install_docs_test.dart
+++ b/test/docs/desktop_install_docs_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression guard for issue #56 ("README download step missed").
+///
+/// Issue #56 reported that the install instructions omitted a required
+/// download step. It was filed against the old "💻 For PC/Desktop (Node.js)"
+/// section of the pre-rewrite userscript era, which no longer exists: Mangatan
+/// is now a Flutter desktop app distributed as prebuilt release assets. The
+/// current README download section, however, only said "get it from the
+/// releases page" without naming the per-platform asset to download or how to
+/// run it — the same "missed download step" class of gap, now for the desktop
+/// app.
+///
+/// This test pins the resolved behaviour so the download instructions can never
+/// silently drift away from the platforms the release workflow actually ships.
+/// The source of truth is `.github/workflows/release.yml`: every desktop
+/// platform it builds-and-uploads MUST have a documented download+run step in
+/// `docs/desktop_install.md`, and the README must point at that guide.
+void main() {
+  final docFile = File('docs/desktop_install.md');
+  final readmeFile = File('README.md');
+  final releaseWorkflow = File('.github/workflows/release.yml');
+
+  /// Desktop platforms Mangatan publishes prebuilt release assets for. Derived
+  /// from the `build-and-release-*` jobs in the release workflow so the
+  /// expectation stays anchored to what CI actually produces.
+  Set<String> desktopPlatformsFromReleaseWorkflow() {
+    final workflow = releaseWorkflow.readAsStringSync();
+    final platforms = <String>{};
+    if (workflow.contains('build-and-release-macos')) {
+      platforms.add('macOS');
+    }
+    if (workflow.contains('build-and-release-windows')) {
+      platforms.add('Windows');
+    }
+    if (workflow.contains('build-and-release-linux')) {
+      platforms.add('Linux');
+    }
+    return platforms;
+  }
+
+  test('desktop install guide exists', () {
+    expect(
+      docFile.existsSync(),
+      isTrue,
+      reason:
+          'docs/desktop_install.md must document the per-platform desktop '
+          'download+run steps (issue #56).',
+    );
+  });
+
+  test('release workflow builds at least one desktop platform', () {
+    // Sanity: the source of truth must not be empty, or the drift guard below
+    // would pass vacuously.
+    expect(
+      desktopPlatformsFromReleaseWorkflow(),
+      isNotEmpty,
+      reason:
+          'Expected the release workflow to define desktop build jobs; the '
+          'download-step drift guard relies on this as its source of truth.',
+    );
+  });
+
+  test(
+    'guide documents a download step for every shipped desktop platform',
+    () {
+      final contents = docFile.readAsStringSync();
+      for (final platform in desktopPlatformsFromReleaseWorkflow()) {
+        expect(
+          contents.contains(platform),
+          isTrue,
+          reason:
+              'docs/desktop_install.md must document the download+run step for '
+              '$platform. The release workflow publishes a $platform asset, so '
+              'omitting it recreates the "missed download step" gap from issue '
+              '#56. Update the guide whenever a desktop platform is added or '
+              'removed.',
+        );
+      }
+    },
+  );
+
+  test('guide names the concrete release asset for each desktop platform', () {
+    final contents = docFile.readAsStringSync();
+    // The exact asset shapes the release workflow uploads. Documenting these
+    // is the "missed step" the issue was about: users must know which file to
+    // grab, not just that a releases page exists.
+    const expectedAssetHints = <String>['.dmg', '.exe', '.zip', '.tar.gz'];
+    for (final hint in expectedAssetHints) {
+      expect(
+        contents.contains(hint),
+        isTrue,
+        reason:
+            'docs/desktop_install.md must name the "$hint" release asset so the '
+            'download step is unambiguous (issue #56).',
+      );
+    }
+  });
+
+  test('README links to the desktop install guide', () {
+    final readme = readmeFile.readAsStringSync();
+    expect(
+      readme.contains('docs/desktop_install.md'),
+      isTrue,
+      reason:
+          'README.md must link to docs/desktop_install.md from its Download '
+          'section so users find the per-platform steps (issue #56).',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Audits historical issue #56 ("README download step missed") against the current origin/main rewrite.

Issue #56 was filed against the old **💻 For PC/Desktop (Node.js)** install section — a userscript-era Node.js flow. That section never existed in this repo's history (`git log --all -S "For PC/Desktop"` returns nothing) and no longer exists anywhere: the rewrite replaced the Node.js userscript with a **Flutter desktop app** distributed as prebuilt release assets. So the *specific* reported defect is obsolete.

However the current README Download section only said "get it from the releases page" without naming which per-platform asset to download or how to run it — the same "missed download step" class of gap, now for the desktop app. Rather than manufacture a no-op change, this PR closes that documentation gap and guards it with a regression test (matching the doc-drift-guard convention established by issue #31 / PR #87).

## Changes

- **`docs/desktop_install.md`** — concrete download + run steps for Windows, macOS, and Linux, grounded in the exact assets `.github/workflows/release.yml` publishes (`*-windows.exe`/`.zip`, `*-macos-arm64.dmg`, `*-linux-x86_64.tar.gz`), plus pointers for Android (Chimahon) and iOS (sideload).
- **`README.md`** — Download section now lists each platform's asset and links to the new guide.
- **`test/docs/desktop_install_docs_test.dart`** — drift guard: fails if a desktop platform built by the release workflow is undocumented, if a concrete asset shape is dropped, or if the README stops linking the guide. The release workflow is the source of truth, so the docs can never silently drift from what CI ships again.

## Test plan

- `flutter test test/docs/desktop_install_docs_test.dart` → 5/5 passed.
- Guard verified real: removing the Linux `.tar.gz` asset from the doc turns the test RED (`must name the ".tar.gz" release asset`); restoring it returns GREEN with the production file at zero diff.
- `dart format --set-exit-if-changed` clean, `flutter analyze` — No issues found, `git diff --check` clean.

No runtime code changed; pubspec build number not bumped (docs/test only, not device-testable per AGENTS.md).

Relates to #56 (already closed by the maintainer; this does not claim to close it).