### PR TITLE
feat(reader): add manual OCR trigger scanning the current page (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Added a manual OCR trigger option to the reader: with "OCR trigger" set to
+  Manual, OCR no longer runs constantly in the background and instead scans the
+  current page on demand when you tap the reader's OCR button. Automatic remains
+  the default and is unchanged. (#35)
+
 ## 1.1.0+166 - 2026-07-30
 
 - Added shared dictionary lookup history to manual, recursive, subtitle, and

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -1132,7 +1132,7 @@ class _MangaChapterPageGalleryState
   // }
 
   Future<void> _showCurrentPageOcr() async {
-    await ReaderOcrState.toggle();
+    await ReaderOcrState.handleOcrButton();
   }
 
   /// Opens the immersion statistics sheet for this manga.

--- a/lib/modules/manga/reader/widgets/reader_app_bar.dart
+++ b/lib/modules/manga/reader/widgets/reader_app_bar.dart
@@ -7,6 +7,7 @@ import 'package:mangayomi/modules/manga/reader/widgets/btn_chapter_list_dialog.d
 import 'package:mangayomi/modules/mining/widgets/reader_ocr_overlay.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/services/mining/mining_preferences.dart';
 import 'package:mangayomi/services/webview_url.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
@@ -139,16 +140,26 @@ class ReaderAppBar extends ConsumerWidget {
   List<Widget> _buildActions(BuildContext context, bool isLocalArchive) {
     return [
       if (onOcrPressed != null)
-        ValueListenableBuilder<bool>(
-          valueListenable: ReaderOcrState.enabled,
-          builder: (context, enabled, _) => IconButton(
-            tooltip: enabled ? 'Hide OCR overlay' : 'Show OCR overlay',
-            onPressed: onOcrPressed,
-            icon: Icon(
-              enabled
-                  ? Icons.document_scanner
-                  : Icons.document_scanner_outlined,
-            ),
+        ValueListenableBuilder<OcrScanTrigger>(
+          valueListenable: ReaderOcrState.scanTrigger,
+          builder: (context, trigger, _) => ValueListenableBuilder<bool>(
+            valueListenable: ReaderOcrState.enabled,
+            builder: (context, enabled, _) {
+              final manual = trigger == OcrScanTrigger.manual;
+              return IconButton(
+                tooltip: manual
+                    ? 'Run OCR on this page'
+                    : (enabled ? 'Hide OCR overlay' : 'Show OCR overlay'),
+                onPressed: onOcrPressed,
+                icon: Icon(
+                  manual
+                      ? Icons.document_scanner_outlined
+                      : (enabled
+                            ? Icons.document_scanner
+                            : Icons.document_scanner_outlined),
+                ),
+              );
+            },
           ),
         ),
 

--- a/lib/modules/manga/reader/widgets/reader_settings_modal.dart
+++ b/lib/modules/manga/reader/widgets/reader_settings_modal.dart
@@ -975,6 +975,37 @@ class _GeneralTab extends ConsumerWidget {
               },
             ),
 
+            ValueListenableBuilder<OcrScanTrigger>(
+              valueListenable: ReaderOcrState.scanTrigger,
+              builder: (context, trigger, _) {
+                return ListTile(
+                  title: const Text('OCR trigger'),
+                  subtitle: Text(switch (trigger) {
+                    OcrScanTrigger.automatic =>
+                      'Automatic (scans pages in the background)',
+                    OcrScanTrigger.manual =>
+                      'Manual (tap the OCR button to scan the current page)',
+                  }),
+                  trailing: PopupMenuButton<OcrScanTrigger>(
+                    initialValue: trigger,
+                    onSelected: (value) {
+                      unawaited(ReaderOcrState.setScanTrigger(value));
+                    },
+                    itemBuilder: (context) => const [
+                      PopupMenuItem(
+                        value: OcrScanTrigger.automatic,
+                        child: Text('Automatic'),
+                      ),
+                      PopupMenuItem(
+                        value: OcrScanTrigger.manual,
+                        child: Text('Manual'),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+
             ValueListenableBuilder<int>(
               valueListenable: ReaderOcrState.parallelOcrLimit,
               builder: (context, limit, _) {

--- a/lib/modules/mining/widgets/reader_ocr_overlay.dart
+++ b/lib/modules/mining/widgets/reader_ocr_overlay.dart
@@ -123,7 +123,7 @@ class ReaderOcrState {
 
   /// Handles a tap on the reader's OCR toolbar button, honoring the configured
   /// [scanTrigger]. In automatic mode it toggles the overlay; in manual mode it
-  /// reveals the overlay if needed and scans the current chapter on demand
+  /// reveals the overlay if needed and scans the current page on demand
   /// (issue #35).
   static Future<void> handleOcrButton() async {
     await initialize();
@@ -135,9 +135,9 @@ class ReaderOcrState {
         await toggle();
       case ReaderOcrButtonAction.enableAndScan:
         await setEnabled(true);
-        await scanCurrentChapterManually();
+        await scanCurrentPageManually();
       case ReaderOcrButtonAction.scan:
-        await scanCurrentChapterManually();
+        await scanCurrentPageManually();
     }
   }
 
@@ -520,24 +520,26 @@ class ReaderOcrState {
     return scan;
   }
 
-  /// Runs OCR for the pending chapter in response to an explicit user request.
+  /// Runs OCR for the current page in response to an explicit user request.
   ///
   /// Used by the manual OCR trigger (issue #35): when [scanTrigger] is
-  /// [OcrScanTrigger.manual] the reader does not auto-scan, so this scans the
-  /// most recently opened chapter on demand. Does nothing when no chapter has
-  /// been opened yet or the overlay is disabled.
-  static Future<void> scanCurrentChapterManually() async {
+  /// [OcrScanTrigger.manual] the reader does not auto-scan, so tapping the OCR
+  /// button scans only the page currently shown — not the whole chapter — so
+  /// OCR runs on demand for the current page instead of constantly in the
+  /// background. Does nothing when no chapter has been opened yet, the overlay
+  /// is disabled, or the current page has no scannable content.
+  static Future<void> scanCurrentPageManually() async {
     await initialize();
     if (!enabled.value || _lastScanPages.isEmpty) return;
-    // Allow the pending chapter to be scanned again even if it was already
-    // marked complete or is being tracked as active from a previous request.
-    _completedScanKey = null;
-    return scanChapter(
+    final page = readerOcrCurrentScanPage(
       _lastScanPages,
       startIndex: _lastStartIndex,
-      preparePage: _lastPreparePage,
-      manual: true,
     );
+    if (page == null) return;
+    // Allow the current page to be scanned again even if it was already marked
+    // complete or is being tracked as active from a previous request.
+    _completedScanKey = null;
+    return scanChapter([page], preparePage: _lastPreparePage, manual: true);
   }
 
   static Future<void> _runChapterScan(
@@ -754,6 +756,28 @@ ReaderOcrButtonAction readerOcrButtonAction({
   return enabled
       ? ReaderOcrButtonAction.scan
       : ReaderOcrButtonAction.enableAndScan;
+}
+
+/// Selects the single page a manual OCR request should scan.
+///
+/// Issue #35 asks for on-click OCR of the *current page* rather than a
+/// whole-chapter background scan, so a manual request must OCR exactly the page
+/// the reader is currently showing (identified by [startIndex] within
+/// [pages]). Transition pages carry no OCR content, so if the current page is a
+/// transition page the nearest following real page (wrapping to earlier pages)
+/// is chosen instead. Returns `null` when there is no scannable page.
+@visibleForTesting
+UChapDataPreload? readerOcrCurrentScanPage(
+  List<UChapDataPreload> pages, {
+  int startIndex = 0,
+}) {
+  if (pages.isEmpty) return null;
+  final start = startIndex.clamp(0, pages.length - 1).toInt();
+  for (var offset = 0; offset < pages.length; offset++) {
+    final page = pages[(start + offset) % pages.length];
+    if (!page.isTransitionPage) return page;
+  }
+  return null;
 }
 
 enum ReaderOcrProgressStage { recognizing, loadingMokuro, mokuro }

--- a/lib/modules/mining/widgets/reader_ocr_overlay.dart
+++ b/lib/modules/mining/widgets/reader_ocr_overlay.dart
@@ -41,6 +41,9 @@ class ReaderOcrState {
   static final engine = ValueNotifier<OcrEnginePreference>(
     OcrEnginePreference.automatic,
   );
+  static final scanTrigger = ValueNotifier<OcrScanTrigger>(
+    OcrScanTrigger.automatic,
+  );
   static final parallelOcrLimit = ValueNotifier<int>(1);
   static bool _initialized = false;
   static Future<void>? _initializing;
@@ -82,6 +85,7 @@ class ReaderOcrState {
         MiningPreferences.getOcrLookupOnHover(),
         MiningPreferences.getOcrEngine(),
         MiningPreferences.getParallelOcrLimit(),
+        MiningPreferences.getOcrScanTrigger(),
         ReaderLookupTriggerState.initialize(),
       ]);
       enabled.value = values[0] as bool;
@@ -91,6 +95,7 @@ class ReaderOcrState {
       lookupOnHover.value = values[4] as bool;
       engine.value = values[5] as OcrEnginePreference;
       parallelOcrLimit.value = values[6] as int;
+      scanTrigger.value = values[7] as OcrScanTrigger;
       _initialized = true;
     } finally {
       _initializing = null;
@@ -115,6 +120,26 @@ class ReaderOcrState {
   }
 
   static Future<void> toggle() => setEnabled(!enabled.value);
+
+  /// Handles a tap on the reader's OCR toolbar button, honoring the configured
+  /// [scanTrigger]. In automatic mode it toggles the overlay; in manual mode it
+  /// reveals the overlay if needed and scans the current chapter on demand
+  /// (issue #35).
+  static Future<void> handleOcrButton() async {
+    await initialize();
+    switch (readerOcrButtonAction(
+      trigger: scanTrigger.value,
+      enabled: enabled.value,
+    )) {
+      case ReaderOcrButtonAction.toggleOverlay:
+        await toggle();
+      case ReaderOcrButtonAction.enableAndScan:
+        await setEnabled(true);
+        await scanCurrentChapterManually();
+      case ReaderOcrButtonAction.scan:
+        await scanCurrentChapterManually();
+    }
+  }
 
   static Future<void> setBackgroundOpacity(double value) async {
     await initialize();
@@ -169,6 +194,27 @@ class ReaderOcrState {
     final clamped = value.clamp(1, 4);
     parallelOcrLimit.value = clamped;
     await MiningPreferences.setParallelOcrLimit(clamped);
+  }
+
+  static Future<void> setScanTrigger(OcrScanTrigger value) async {
+    await initialize();
+    if (scanTrigger.value == value) return;
+    scanTrigger.value = value;
+    await MiningPreferences.setOcrScanTrigger(value);
+    // Switching back to automatic scans any pending chapter immediately;
+    // switching to manual leaves already-scanned pages untouched and simply
+    // stops future background scans.
+    if (value == OcrScanTrigger.automatic &&
+        enabled.value &&
+        _lastScanPages.isNotEmpty) {
+      unawaited(
+        scanChapter(
+          _lastScanPages,
+          startIndex: _lastStartIndex,
+          preparePage: _lastPreparePage,
+        ),
+      );
+    }
   }
 
   static bool handlePointerUp(Offset globalPosition) {
@@ -418,12 +464,23 @@ class ReaderOcrState {
     List<UChapDataPreload> pages, {
     int startIndex = 0,
     Future<void> Function(UChapDataPreload)? preparePage,
+    bool manual = false,
   }) async {
     _lastScanPages = pages;
     _lastStartIndex = startIndex;
     _lastPreparePage = preparePage;
     await initialize();
     if (!enabled.value) return;
+    // Manual trigger mode keeps OCR idle until the reader explicitly requests a
+    // scan, so it does not run constantly in the background (issue #35). The
+    // pending pages are still recorded above so a later manual request can scan
+    // them.
+    if (!readerOcrShouldAutoScan(
+      trigger: scanTrigger.value,
+      manualRequest: manual,
+    )) {
+      return;
+    }
     final scanPages = pages.where((page) => !page.isTransitionPage).toList();
     if (scanPages.isEmpty) return;
     final scanKey = readerOcrChapterScanKey(scanPages);
@@ -461,6 +518,26 @@ class ReaderOcrState {
     _activeScanKey = scanKey;
     _activeScan = scan;
     return scan;
+  }
+
+  /// Runs OCR for the pending chapter in response to an explicit user request.
+  ///
+  /// Used by the manual OCR trigger (issue #35): when [scanTrigger] is
+  /// [OcrScanTrigger.manual] the reader does not auto-scan, so this scans the
+  /// most recently opened chapter on demand. Does nothing when no chapter has
+  /// been opened yet or the overlay is disabled.
+  static Future<void> scanCurrentChapterManually() async {
+    await initialize();
+    if (!enabled.value || _lastScanPages.isEmpty) return;
+    // Allow the pending chapter to be scanned again even if it was already
+    // marked complete or is being tracked as active from a previous request.
+    _completedScanKey = null;
+    return scanChapter(
+      _lastScanPages,
+      startIndex: _lastStartIndex,
+      preparePage: _lastPreparePage,
+      manual: true,
+    );
   }
 
   static Future<void> _runChapterScan(
@@ -634,6 +711,50 @@ bool readerOcrShouldStartChapterScan({
   String? activeScanKey,
   String? completedScanKey,
 }) => activeScanKey != scanKey && completedScanKey != scanKey;
+
+/// Decides whether a chapter OCR scan should run given the configured
+/// [trigger] and whether this scan was explicitly [manualRequest]ed.
+///
+/// In [OcrScanTrigger.automatic] mode OCR always runs (the historical
+/// behavior). In [OcrScanTrigger.manual] mode background scans are suppressed
+/// so OCR does not run constantly; it runs only when the reader explicitly
+/// requests it. See issue #35.
+@visibleForTesting
+bool readerOcrShouldAutoScan({
+  required OcrScanTrigger trigger,
+  required bool manualRequest,
+}) => trigger == OcrScanTrigger.automatic || manualRequest;
+
+/// What the reader's OCR toolbar button should do when tapped.
+enum ReaderOcrButtonAction {
+  /// Show or hide the OCR overlay (automatic trigger behavior).
+  toggleOverlay,
+
+  /// Reveal the overlay and immediately scan the current page (manual trigger,
+  /// overlay currently hidden).
+  enableAndScan,
+
+  /// Scan the current page without changing overlay visibility (manual trigger,
+  /// overlay already shown).
+  scan,
+}
+
+/// Chooses the OCR toolbar button behavior for the current [trigger] and
+/// overlay [enabled] state. In automatic mode the button keeps toggling the
+/// overlay; in manual mode it launches OCR for the current page on demand so
+/// OCR does not run constantly in the background (issue #35).
+@visibleForTesting
+ReaderOcrButtonAction readerOcrButtonAction({
+  required OcrScanTrigger trigger,
+  required bool enabled,
+}) {
+  if (trigger == OcrScanTrigger.automatic) {
+    return ReaderOcrButtonAction.toggleOverlay;
+  }
+  return enabled
+      ? ReaderOcrButtonAction.scan
+      : ReaderOcrButtonAction.enableAndScan;
+}
 
 enum ReaderOcrProgressStage { recognizing, loadingMokuro, mokuro }
 

--- a/lib/services/mining/mining_preferences.dart
+++ b/lib/services/mining/mining_preferences.dart
@@ -10,6 +10,14 @@ import 'package:path/path.dart' as p;
 
 enum OcrEnginePreference { automatic, screenAi, googleLens, mokuroOnly }
 
+/// Controls when reader OCR runs.
+///
+/// [automatic] scans the whole chapter in the background as soon as it opens
+/// (the historical default). [manual] leaves OCR idle until the reader
+/// explicitly requests a scan, so it does not run constantly in the
+/// background. See issue #35.
+enum OcrScanTrigger { automatic, manual }
+
 enum DictionaryThemePreference { system, light, dark, black }
 
 enum DictionaryLookupTrigger { leftClick, shift, middleClick }
@@ -332,6 +340,7 @@ class MiningPreferences {
   static const _ankiAudioTimeoutMs = 'anki_audio_timeout_ms';
   static const _ankiAudioLanguage = 'anki_audio_language';
   static const _ocrEngine = 'ocr_engine';
+  static const _ocrScanTrigger = 'ocr_scan_trigger';
   static const _parallelOcrLimit = 'parallel_ocr_limit';
   static const _subtitleRegexFilters = 'subtitle_regex_filters';
   static const _readerEInkMode = 'reader_eink_mode';
@@ -973,6 +982,27 @@ class MiningPreferences {
 
   static Future<void> setOcrEngine(OcrEnginePreference value) async {
     await (await _boxOrNull())?.put(_ocrEngine, value.name);
+  }
+
+  static Future<OcrScanTrigger> getOcrScanTrigger({
+    bool readOnly = false,
+    MiningPreferencesSnapshot? snapshot,
+  }) async {
+    final name =
+        (await _reader(readOnly: readOnly, snapshot: snapshot))?.get(
+              _ocrScanTrigger,
+              defaultValue: OcrScanTrigger.automatic.name,
+            )
+            as String? ??
+        OcrScanTrigger.automatic.name;
+    return OcrScanTrigger.values.firstWhere(
+      (value) => value.name == name,
+      orElse: () => OcrScanTrigger.automatic,
+    );
+  }
+
+  static Future<void> setOcrScanTrigger(OcrScanTrigger value) async {
+    await (await _boxOrNull())?.put(_ocrScanTrigger, value.name);
   }
 
   static Future<int> getParallelOcrLimit() async {

--- a/test/modules/mining/reader_ocr_manual_trigger_test.dart
+++ b/test/modules/mining/reader_ocr_manual_trigger_test.dart
@@ -79,6 +79,58 @@ void main() {
     });
   });
 
+  group('readerOcrCurrentScanPage', () {
+    UChapDataPreload page(int index, {bool isTransitionPage = false}) =>
+        UChapDataPreload(
+          null,
+          null,
+          null,
+          !isTransitionPage,
+          null,
+          index,
+          null,
+          index,
+          isTransitionPage: isTransitionPage,
+          localArtifactPath: 'current-page/page-$index.avif',
+        );
+
+    test('returns the page at the current start index only', () {
+      final pages = [page(0), page(1), page(2)];
+      expect(
+        readerOcrCurrentScanPage(pages, startIndex: 1)?.pageIndex,
+        1,
+        reason: 'a manual scan must target the current page, not the chapter',
+      );
+    });
+
+    test('defaults to the first page when no index is given', () {
+      final pages = [page(5), page(6)];
+      expect(readerOcrCurrentScanPage(pages)?.pageIndex, 5);
+    });
+
+    test('clamps an out-of-range index to the last page', () {
+      final pages = [page(0), page(1)];
+      expect(readerOcrCurrentScanPage(pages, startIndex: 99)?.pageIndex, 1);
+    });
+
+    test('skips a transition current page to the next real page', () {
+      final pages = [page(0), page(1, isTransitionPage: true), page(2)];
+      expect(readerOcrCurrentScanPage(pages, startIndex: 1)?.pageIndex, 2);
+    });
+
+    test('returns null when every page is a transition page', () {
+      final pages = [
+        page(0, isTransitionPage: true),
+        page(1, isTransitionPage: true),
+      ];
+      expect(readerOcrCurrentScanPage(pages, startIndex: 0), isNull);
+    });
+
+    test('returns null for an empty page list', () {
+      expect(readerOcrCurrentScanPage(const [], startIndex: 0), isNull);
+    });
+  });
+
   group('OcrScanTrigger preference', () {
     late Directory tempDirectory;
 
@@ -183,26 +235,30 @@ void main() {
       );
     });
 
-    test('manual request scans the pending chapter on demand', () async {
+    test('manual request scans only the current page on demand', () async {
       await MiningPreferences.setOcrScanTrigger(OcrScanTrigger.manual);
-      var prepared = 0;
+      final prepared = <int>[];
 
-      // Opening the chapter stores the pending pages without scanning.
+      // Opening the chapter at page index 11 (the second of three) stores the
+      // pending pages without scanning anything.
       await ReaderOcrState.scanChapter(
-        [page(10), page(11)],
-        preparePage: (_) async {
-          prepared++;
+        [page(10), page(11), page(12)],
+        startIndex: 1,
+        preparePage: (target) async {
+          prepared.add(target.pageIndex ?? -1);
           throw StateError('stop before real OCR');
         },
       );
-      expect(prepared, 0);
+      expect(prepared, isEmpty);
 
-      // An explicit user request now runs OCR for the pending chapter.
-      await ReaderOcrState.scanCurrentChapterManually();
+      // An explicit user request now runs OCR for ONLY the current page (11),
+      // not the whole chapter — this is the issue #35 on-click behavior.
+      await ReaderOcrState.scanCurrentPageManually();
       expect(
         prepared,
-        greaterThan(0),
-        reason: 'a manual request must scan the pending chapter',
+        [11],
+        reason:
+            'a manual request must scan only the current page, not the chapter',
       );
     });
   });

--- a/test/modules/mining/reader_ocr_manual_trigger_test.dart
+++ b/test/modules/mining/reader_ocr_manual_trigger_test.dart
@@ -1,0 +1,209 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:mangayomi/modules/manga/reader/u_chap_data_preload.dart';
+import 'package:mangayomi/modules/mining/widgets/reader_ocr_overlay.dart';
+import 'package:mangayomi/services/mining/mining_preferences.dart';
+
+void main() {
+  group('readerOcrShouldAutoScan', () {
+    test('automatic trigger auto-scans without an explicit request', () {
+      expect(
+        readerOcrShouldAutoScan(
+          trigger: OcrScanTrigger.automatic,
+          manualRequest: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('manual trigger does not auto-scan on chapter open', () {
+      expect(
+        readerOcrShouldAutoScan(
+          trigger: OcrScanTrigger.manual,
+          manualRequest: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('manual trigger scans when the user explicitly requests it', () {
+      expect(
+        readerOcrShouldAutoScan(
+          trigger: OcrScanTrigger.manual,
+          manualRequest: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('automatic trigger still scans for an explicit request', () {
+      expect(
+        readerOcrShouldAutoScan(
+          trigger: OcrScanTrigger.automatic,
+          manualRequest: true,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('readerOcrButtonAction', () {
+    test('automatic mode toggles the overlay', () {
+      expect(
+        readerOcrButtonAction(trigger: OcrScanTrigger.automatic, enabled: true),
+        ReaderOcrButtonAction.toggleOverlay,
+      );
+      expect(
+        readerOcrButtonAction(
+          trigger: OcrScanTrigger.automatic,
+          enabled: false,
+        ),
+        ReaderOcrButtonAction.toggleOverlay,
+      );
+    });
+
+    test('manual mode with overlay hidden reveals then scans', () {
+      expect(
+        readerOcrButtonAction(trigger: OcrScanTrigger.manual, enabled: false),
+        ReaderOcrButtonAction.enableAndScan,
+      );
+    });
+
+    test('manual mode with overlay visible scans the current page', () {
+      expect(
+        readerOcrButtonAction(trigger: OcrScanTrigger.manual, enabled: true),
+        ReaderOcrButtonAction.scan,
+      );
+    });
+  });
+
+  group('OcrScanTrigger preference', () {
+    late Directory tempDirectory;
+
+    setUpAll(() async {
+      tempDirectory = await Directory.systemTemp.createTemp(
+        'mangatan-ocr-trigger-preferences-',
+      );
+      Hive.init(tempDirectory.path);
+    });
+
+    setUp(() async {
+      if (Hive.isBoxOpen('mining_preferences')) {
+        await Hive.box<dynamic>('mining_preferences').close();
+      }
+      await Hive.deleteBoxFromDisk('mining_preferences');
+    });
+
+    tearDownAll(() async {
+      await Hive.close();
+      if (await tempDirectory.exists()) {
+        await tempDirectory.delete(recursive: true);
+      }
+    });
+
+    test('defaults to automatic to preserve existing behavior', () async {
+      expect(
+        await MiningPreferences.getOcrScanTrigger(),
+        OcrScanTrigger.automatic,
+      );
+    });
+
+    test('persists the manual trigger across box reopen', () async {
+      await MiningPreferences.setOcrScanTrigger(OcrScanTrigger.manual);
+      await Hive.box<dynamic>('mining_preferences').close();
+
+      expect(
+        await MiningPreferences.getOcrScanTrigger(),
+        OcrScanTrigger.manual,
+      );
+    });
+
+    test('falls back to automatic for an unknown stored value', () async {
+      final box = await Hive.openBox<dynamic>('mining_preferences');
+      await box.put('ocr_scan_trigger', 'not-a-real-mode');
+
+      expect(
+        await MiningPreferences.getOcrScanTrigger(),
+        OcrScanTrigger.automatic,
+      );
+    });
+  });
+
+  group('ReaderOcrState scan gating', () {
+    late Directory tempDirectory;
+
+    UChapDataPreload page(int index) => UChapDataPreload(
+      null,
+      null,
+      null,
+      true,
+      null,
+      index,
+      null,
+      index,
+      localArtifactPath: 'gating-chapter/page-$index.avif',
+    );
+
+    setUpAll(() async {
+      tempDirectory = await Directory.systemTemp.createTemp(
+        'mangatan-ocr-gating-preferences-',
+      );
+      Hive.init(tempDirectory.path);
+    });
+
+    tearDownAll(() async {
+      await Hive.close();
+      if (await tempDirectory.exists()) {
+        await tempDirectory.delete(recursive: true);
+      }
+    });
+
+    tearDown(() {
+      ReaderOcrState.progress.value = null;
+    });
+
+    test('manual trigger suppresses the automatic chapter scan', () async {
+      await MiningPreferences.setOcrScanTrigger(OcrScanTrigger.manual);
+      var prepared = 0;
+
+      await ReaderOcrState.scanChapter(
+        [page(0), page(1)],
+        preparePage: (_) async {
+          prepared++;
+          throw StateError('stop before real OCR');
+        },
+      );
+
+      expect(
+        prepared,
+        0,
+        reason: 'manual mode must not scan pages in the background',
+      );
+    });
+
+    test('manual request scans the pending chapter on demand', () async {
+      await MiningPreferences.setOcrScanTrigger(OcrScanTrigger.manual);
+      var prepared = 0;
+
+      // Opening the chapter stores the pending pages without scanning.
+      await ReaderOcrState.scanChapter(
+        [page(10), page(11)],
+        preparePage: (_) async {
+          prepared++;
+          throw StateError('stop before real OCR');
+        },
+      );
+      expect(prepared, 0);
+
+      // An explicit user request now runs OCR for the pending chapter.
+      await ReaderOcrState.scanCurrentChapterManually();
+      expect(
+        prepared,
+        greaterThan(0),
+        reason: 'a manual request must scan the pending chapter',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Re-does the manual OCR trigger feature from #35 after PR #90 was closed in review.

The maintainer closed #90 with:

> Closing after review and focused/ad-hoc testing. The UI promises manual OCR for the current page, but `scanCurrentChapterManually` forwards the complete chapter page list and scans the whole chapter starting at the current page. That does not deliver issue #35's requested on-click current-page behavior.

That was correct: manual mode still OCR'd the whole chapter (just reordered to start at the current page), so it did not deliver the on-click **current-page** behavior issue #35 asked for. This PR fixes exactly that.

## What changed vs the closed PR #90

- Replaced `ReaderOcrState.scanCurrentChapterManually()` with `scanCurrentPageManually()`, which OCRs **only the page the reader is currently showing** — not the chapter.
- Added a pure, `@visibleForTesting` helper `readerOcrCurrentScanPage(pages, startIndex)` that selects the current page and skips transition pages (wrapping to the nearest real page), returning `null` when nothing is scannable.
- `handleOcrButton()` now routes both manual actions (`scan`, `enableAndScan`) through the current-page scan.
- Doc comments updated to describe current-page (not whole-chapter) behavior.

The `OcrScanTrigger` preference (Automatic default / Manual), the settings selector, and the app-bar button from #90 are unchanged; Automatic mode still auto-scans chapters in the background exactly as before.

## Test plan (TDD, RED -> GREEN)

`test/modules/mining/reader_ocr_manual_trigger_test.dart`:

- New `readerOcrCurrentScanPage` group: current-index selection, default-to-first, out-of-range clamp, transition-page skip, all-transition -> null, empty-list -> null.
- Rewrote the manual-request gating test to assert a manual request scans **only** the current page (`[11]`), not the whole chapter. Falsification check: reverting the production line to forward the full chapter list makes this test go RED with `Actual: [11, 12, 10]` vs `Expected: [11]`; restoring it is GREEN with the production file at zero diff.

```
flutter test test/modules/mining/reader_ocr_manual_trigger_test.dart   # +18 All tests passed
flutter test test/services/m_extension_server_test.dart                # +4 All tests passed (AGENTS.md gate)
flutter test test/modules/mining/ test/services/mining/                # +178 (2 pre-existing failures need ffmpeg/avifenc, unrelated)
flutter analyze <touched files>                                        # No issues found
dart format --set-exit-if-changed <touched files>                      # clean
git diff --check                                                       # clean
```

Cross-platform Dart-only change; no native/iOS changes, so no pubspec build-number bump (per AGENTS.md, that is reserved for device-testable IPA builds).

Links #35 for context and supersedes the closed PR #90. Does not claim to close the already-closed issue.
