### PR TITLE
docs: code-grounded OCR engine privacy notes (Refs #31)

### DIFF
--- a/docs/ocr_engines.md
+++ b/docs/ocr_engines.md
@@ -1,0 +1,121 @@
+# OCR engines and what leaves your device
+
+Mangatan can read text off a manga page with several OCR ("optical character
+recognition") back-ends. You pick one under **Reader settings → OCR engine**.
+This page documents, grounded in the current code, **where each engine runs**
+and **what data leaves your device**, so you can choose one that matches your
+privacy expectations.
+
+> Every claim below is tied to the source that proves it. The dispatch order
+> lives in `_recognize()` in
+> `lib/modules/mining/widgets/reader_ocr_overlay.dart`; the engine list is
+> `enum OcrEnginePreference { automatic, screenAi, googleLens, mokuroOnly }` in
+> `lib/services/mining/mining_preferences.dart`.
+
+## The engines
+
+| Engine (setting) | Where inference runs | Network request it can make |
+| --- | --- | --- |
+| **Automatic** (default) | Mixed — prefers local, **falls back to the cloud** | Google Lens, and Mokuro-website (see below) |
+| **ScreenAI (local Chrome)** | On-device (Windows only) | None for inference; Mokuro-website may still fire (see below) |
+| **Google Lens** | Remote Google endpoint | Google Lens, and Mokuro-website (see below) |
+| **Mokuro only** | Local pre-generated data | None for inference; Mokuro-website may still fire (see below) |
+
+### Automatic — NOT isolated; can silently use the cloud
+
+`Automatic` is a cascade, not a single engine. For a page with no local Mokuro
+data it tries **ScreenAI** if it is installed, and **if ScreenAI is
+unavailable or returns nothing it falls through to Google Lens**, which uploads
+the page image to Google. This fall-through is unconditional — there is no
+prompt — so choosing `Automatic` means page images **may be sent to Google**
+without any further confirmation.
+
+Proof: after the local Mokuro checks, `_recognize()` computes
+`shouldTryScreenAi = engine == screenAi || (engine == automatic && await
+ScreenAiOcrClient.isAvailable())`. When that is false (or ScreenAI throws and
+the engine is *not* `screenAi`, so the error is swallowed), control reaches the
+final unconditional `ChromeLensOcrClient().recognize(...)` block
+(`reader_ocr_overlay.dart`, `_recognize`).
+
+### ScreenAI (local Chrome) — on-device, Windows only, no OCR upload
+
+ScreenAI runs Chrome's/Edge's bundled `chrome_screen_ai.dll` locally through
+FFI; the page image is decoded and recognized on your machine and **no page
+image is uploaded for recognition**. If ScreenAI is unavailable or fails, this
+engine **rethrows the error instead of falling back to Google Lens** — so
+selecting it explicitly does not silently send your page to the cloud.
+
+Proof: `ScreenAiOcrClient.recognize()` calls a native DLL via
+`_ScreenAiBridge` inside an isolate and makes no HTTP call
+(`lib/services/mining/screen_ai_ocr.dart`). In `_recognize()`, the ScreenAI
+`catch (_)` block does `if (engine == screenAi) rethrow;`, and the success path
+returns for `screenAi` even when zero blocks are found — neither reaches the
+Google Lens block.
+
+Requirements/limits, from the code:
+
+- **Windows only.** `ScreenAiOcrClient.isAvailable()` returns
+  `Platform.isWindows && _ScreenAiBridge.isAvailable && _findComponentDirectory() != null`;
+  `recognize()` throws `UnsupportedError` off Windows.
+- **No manual DLL install.** The component is located automatically by scanning
+  Chrome / Chrome SxS / Edge `User Data\screen_ai\<version>` for
+  `chrome_screen_ai.dll` + `manifest.json` (`_findComponentDirectory()`). If it
+  is missing you get "ScreenAI is not installed. Open Chrome once or select
+  Google Lens." — you do not copy any file by hand.
+
+### Google Lens — remote, page image is uploaded
+
+Selecting Google Lens sends the page image to a Google endpoint and returns the
+recognized text. The image (downscaled, see below) leaves your device on every
+recognition.
+
+Proof: `ChromeLensOcrClient` POSTs the encoded image to
+`https://lensfrontend-pa.googleapis.com/v1/crupload` with an API key and a
+Chrome user-agent (`lib/services/mining/chrome_lens_ocr.dart`). Before upload
+the image is capped at `_maxDimension = 1500` px, but the **page pixels
+themselves are transmitted** to Google. No text besides the image is sent, and
+the response is parsed locally.
+
+### Mokuro only — local pre-generated data, no OCR service
+
+`Mokuro only` uses OCR text that was generated ahead of time (a `.mokuro`
+sidecar). It **never** calls ScreenAI or Google Lens: if no local Mokuro data
+resolves for the page, it returns **no** OCR blocks rather than falling back.
+
+Proof: in `_recognize()`, `if (engine == mokuroOnly)` returns an empty
+`_ReaderOcrPage` after the Mokuro checks, before the image bytes are read and
+before either the ScreenAI or Google Lens block.
+
+## The shared caveat: the Mokuro website fetch
+
+Independently of the engine you pick, a separate toggle **"Mokuro website OCR"**
+(`getMokuroWebsiteOcrEnabled()`, **default `true`**) can make Mangatan download
+a pre-generated `.mokuro` volume from **`https://mokuro.moe`**. This runs for
+*every* engine — including `ScreenAI` and `Mokuro only` — **but only when the
+manga's source is named `mokuro`** (`MokuroExtensionOcrClient.volumeUri()`
+returns `null` for any other source, so no request is made).
+
+Proof: `_recognize()` runs `if (useMokuroWebsiteOcr) { MokuroExtensionOcrClient().fetchVolume(...) }`
+before the engine-specific ScreenAI/Lens branches;
+`MokuroExtensionOcrClient` targets `https://mokuro.moe/...` and short-circuits
+to `null` unless `sourceName.trim().toLowerCase() == 'mokuro'`
+(`lib/services/mining/mokuro_extension_ocr.dart`). So "local" engines are local
+for *inference*, but this separate feature can still contact `mokuro.moe` for a
+Mokuro source unless you turn it off.
+
+## Choosing an engine for privacy
+
+- **No page images to any third party:** pick **ScreenAI** (Windows) or
+  **Mokuro only**, and — if you read a `mokuro` source — turn **Mokuro website
+  OCR** off.
+- **Best coverage, cloud is acceptable:** **Automatic** or **Google Lens**;
+  both can upload page images to Google.
+- Note that **Automatic is not a private choice**: it uploads to Google Lens
+  whenever local recognition is unavailable or empty.
+
+The sync layer classifies only the two unambiguous engines: Google Lens exports
+as `cloud` and ScreenAI as `local`; `automatic` and `mokuroOnly` are left
+unset because they are not a single fixed location
+(`lib/services/sync/chimahon_mining_settings_adapter.dart`).
+
+Refs #31.

--- a/test/services/mining/ocr_engine_docs_test.dart
+++ b/test/services/mining/ocr_engine_docs_test.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/mining/mining_preferences.dart';
+
+/// Docs-drift guard for `docs/ocr_engines.md`.
+///
+/// This test only verifies *structural* coverage: that every
+/// [OcrEnginePreference] value is documented, and that endpoint strings the doc
+/// cites still match the source constants. It deliberately does NOT try to
+/// validate semantic privacy claims (where inference runs, what data leaves the
+/// device) — those are grounded by the code citations in the PR body and cannot
+/// be asserted by a string test. Keeping that boundary explicit is why PR #87's
+/// enum-name-only test was insufficient.
+void main() {
+  final root = _repoRoot();
+  final docFile = File('${root.path}/docs/ocr_engines.md');
+  final docText = docFile.existsSync() ? docFile.readAsStringSync() : '';
+
+  test('OCR engine documentation exists', () {
+    expect(
+      docFile.existsSync(),
+      isTrue,
+      reason: 'docs/ocr_engines.md must exist so engine choices are documented',
+    );
+  });
+
+  test('every OcrEnginePreference value is documented', () {
+    // Human-facing labels the doc is expected to explain, keyed by enum value.
+    // If a new engine is added to the enum without a matching label here, this
+    // map is incomplete and the test below (the enum-count check) fails.
+    const expectedLabels = <OcrEnginePreference, String>{
+      OcrEnginePreference.automatic: 'Automatic',
+      OcrEnginePreference.screenAi: 'ScreenAI',
+      OcrEnginePreference.googleLens: 'Google Lens',
+      OcrEnginePreference.mokuroOnly: 'Mokuro only',
+    };
+
+    expect(
+      expectedLabels.keys.toSet(),
+      OcrEnginePreference.values.toSet(),
+      reason:
+          'A new OcrEnginePreference value was added; document it in '
+          'docs/ocr_engines.md and add its label to this test.',
+    );
+
+    for (final entry in expectedLabels.entries) {
+      expect(
+        docText.contains(entry.value),
+        isTrue,
+        reason:
+            'docs/ocr_engines.md is missing a section for '
+            '${entry.key.name} (expected label "${entry.value}")',
+      );
+    }
+  });
+
+  test('documented Google Lens endpoint matches the client constant', () {
+    // The doc names a concrete remote endpoint for Google Lens. Pin it to the
+    // real source so the doc cannot drift to a stale/fabricated URL.
+    final clientText = File(
+      '${root.path}/lib/services/mining/chrome_lens_ocr.dart',
+    ).readAsStringSync();
+    const endpointHost = 'lensfrontend-pa.googleapis.com';
+
+    expect(
+      clientText.contains(endpointHost),
+      isTrue,
+      reason: 'Google Lens client no longer targets $endpointHost',
+    );
+    expect(
+      docText.contains(endpointHost),
+      isTrue,
+      reason:
+          'docs/ocr_engines.md must name the real Google Lens endpoint '
+          '($endpointHost) it claims the page image is uploaded to',
+    );
+  });
+
+  test('documented Mokuro-website host matches the client constant', () {
+    final clientText = File(
+      '${root.path}/lib/services/mining/mokuro_extension_ocr.dart',
+    ).readAsStringSync();
+    const mokuroHost = 'mokuro.moe';
+
+    expect(
+      clientText.contains(mokuroHost),
+      isTrue,
+      reason: 'Mokuro extension client no longer targets $mokuroHost',
+    );
+    expect(
+      docText.contains(mokuroHost),
+      isTrue,
+      reason:
+          'docs/ocr_engines.md must name the Mokuro-website host ($mokuroHost) '
+          'it warns can be contacted regardless of engine',
+    );
+  });
+}
+
+/// Walks up from the test file until it finds the repo root (identified by
+/// `pubspec.yaml`), so the test resolves the same paths under `flutter test`
+/// regardless of the current working directory.
+Directory _repoRoot() {
+  var dir = Directory.current;
+  for (var i = 0; i < 8; i++) {
+    if (File('${dir.path}/pubspec.yaml').existsSync() &&
+        Directory('${dir.path}/lib/services/mining').existsSync()) {
+      return dir;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  return Directory.current;
+}


### PR DESCRIPTION
## Summary

Re-does issue #31's OCR engine documentation after PR #87 was closed by the
maintainer for **behavior/privacy inaccuracies about engine isolation and
network fallback**. This PR grounds *every* claim in the current code and, where
the code does not guarantee isolation, says so plainly instead of asserting it.

Fresh branch off `origin/main` (PR #87's branch was **not** reused). New files:

- `docs/ocr_engines.md` — user-facing, code-grounded engine/privacy notes.
- `test/services/mining/ocr_engine_docs_test.dart` — a **structural** docs-drift
  guard only (see caveat below).

No behavior changes.

## What PR #87 got wrong, and the correction

PR #87 implied the engines were cleanly isolated by locality and did not
surface that "Automatic" silently uploads to the cloud, nor that the
Mokuro-website fetch fires regardless of engine. Both are corrected here.

## Claim → code citation table

Every semantic claim in `docs/ocr_engines.md` is tied to the source that proves
it. Dispatch order is `_recognize()` in
`lib/modules/mining/widgets/reader_ocr_overlay.dart`.

| Doc claim | Code proof |
| --- | --- |
| Engines are `automatic`, `screenAi`, `googleLens`, `mokuroOnly` | `enum OcrEnginePreference { automatic, screenAi, googleLens, mokuroOnly }` — `lib/services/mining/mining_preferences.dart:11` |
| **Automatic is NOT isolated: it silently falls through to Google Lens (cloud)** when local OCR is unavailable/empty | `_recognize()`: `shouldTryScreenAi = engine==screenAi || (engine==automatic && await ScreenAiOcrClient.isAvailable())`; when false, or ScreenAI throws and engine≠screenAi (error swallowed), control reaches the **unconditional** `ChromeLensOcrClient().recognize(...)` block — `reader_ocr_overlay.dart` `_recognize` (≈lines 1359–1394) |
| **ScreenAI is on-device, Windows-only, and does NOT fall back to Lens** (rethrows on failure) | `ScreenAiOcrClient.recognize()` runs the native `chrome_screen_ai.dll` via FFI in an isolate, no HTTP — `lib/services/mining/screen_ai_ocr.dart`; in `_recognize()` the ScreenAI `catch (_)` does `if (engine==screenAi) rethrow;` and its success path returns for `screenAi` even with zero blocks — neither reaches the Lens block |
| ScreenAI needs **no** manual `oneocr.dll` / `.config/oneocr` install | `_findComponentDirectory()` auto-scans Chrome/Chrome SxS/Edge `User Data\screen_ai\<version>` for `chrome_screen_ai.dll` + `manifest.json` — `screen_ai_ocr.dart:155-177` |
| ScreenAI is Windows-only | `isAvailable()` = `Platform.isWindows && _ScreenAiBridge.isAvailable && _findComponentDirectory()!=null`; `recognize()` throws `UnsupportedError` off Windows — `screen_ai_ocr.dart:66-75` |
| **Google Lens uploads the page image** to a named remote endpoint | `ChromeLensOcrClient` POSTs the encoded image to `https://lensfrontend-pa.googleapis.com/v1/crupload` — `lib/services/mining/chrome_lens_ocr.dart:24-57`; image capped at `_maxDimension = 1500`px before upload (`:32`) |
| **Mokuro only never calls ScreenAI or Google Lens**; returns empty if no local data | `_recognize()`: `if (engine==mokuroOnly) return _ReaderOcrPage(blocks: const [], ...)` before the image read and before the ScreenAI/Lens branches (≈line 1345) |
| **Mokuro-website fetch (`mokuro.moe`) can fire for ANY engine**, but only for a `mokuro` source; default ON | `_recognize()`: `if (useMokuroWebsiteOcr) { MokuroExtensionOcrClient().fetchVolume(...) }` runs before the engine branches; client targets `https://mokuro.moe/...` and returns `null` unless `sourceName.trim().toLowerCase()=='mokuro'` — `lib/services/mining/mokuro_extension_ocr.dart:29,41,50-55`; `getMokuroWebsiteOcrEnabled()` `defaultValue: true` — `mining_preferences.dart:1011-1018` |
| Sync exports only `googleLens→cloud`, `screenAi→local`; `automatic`/`mokuroOnly` unset | `_exportOcrEngine` switch — `lib/services/sync/chimahon_mining_settings_adapter.dart:405-409` |

## About the test (why the enum-name approach was insufficient)

PR #87's test only checked enum names, which — as the maintainer noted — cannot
catch semantic errors. This test is deliberately scoped as a **structural
drift guard** and its doc comment says so: it asserts (a) every
`OcrEnginePreference` value is documented, and (b) the endpoint hosts the doc
cites (`lensfrontend-pa.googleapis.com`, `mokuro.moe`) still match the client
constants. It does **not** pretend to validate the privacy semantics — those
are reviewed via the citation table above. Removing the endpoint from the doc
was confirmed to turn the test RED, then restored to GREEN.

## Verification (Linux host)

- `dart format` on the new test → clean (0 changed).
- `flutter analyze test/services/mining/ocr_engine_docs_test.dart` → No issues found.
- `flutter test test/services/mining/ocr_engine_docs_test.dart` → **4/4 passed**;
  falsification: removed the Lens endpoint from the doc → RED, restored → GREEN,
  doc at zero diff.
- `flutter test test/services/m_extension_server_test.dart` (AGENTS.md required) → passed.
- `git diff --check` → clean.

No `pubspec` build-number bump: docs + a test, not a device-testable native
change (AGENTS.md requires the bump only for a device-testable IPA).

Refs #31
