### PR TITLE
fix(mining): valid total ordering for Japanese reading order (issue #34)

### DIFF
--- a/lib/services/mining/ocr_block_merger.dart
+++ b/lib/services/mining/ocr_block_merger.dart
@@ -291,16 +291,80 @@ OcrTextBlock _toBlock(List<_Line> lines, String language) {
   );
 }
 
+/// Orders reading blocks with a mathematically valid total ordering.
+///
+/// The previous implementation compared pairs of blocks with an
+/// overlap-conditional axis flip (compare on x when the two boxes share a row,
+/// otherwise on y). That relation is not transitive: for three boxes A, B, C
+/// where A/B and B/C each share a row but A/C do not, the pairwise decisions
+/// can contradict, so [List.sort] produced order-dependent, inconsistent
+/// results and mis-ordered multi-row grids.
+///
+/// Instead, rows ("bands") are computed once up front by clustering blocks on
+/// their vertical extent, giving every block a single integer band index. The
+/// blocks are then sorted by a fixed lexicographic key derived only from that
+/// precomputed index and the block's own coordinates:
+///
+///   (bandIndex, reading-x, ymin, xmin)
+///
+/// where reading-x runs right-to-left for vertical Japanese and left-to-right
+/// otherwise. Because the key is a pure function of each block (never of the
+/// pair being compared), the comparator is antisymmetric and transitive — a
+/// valid total ordering — and the final `ymin`/`xmin` tie-breakers make it a
+/// strict order, so sorting is deterministic regardless of input order.
 List<OcrTextBlock> _readingOrder(List<OcrTextBlock> blocks, bool japanese) {
+  if (blocks.length < 2) return blocks;
+  final bands = _rowBands(blocks);
+  double readingX(OcrTextBlock block) => japanese ? -block.xmin : block.xmin;
   blocks.sort((a, b) {
-    final overlap = _overlap(a.ymin, a.ymax, b.ymin, b.ymax);
-    if (overlap > 0.2) {
-      return japanese ? b.xmin.compareTo(a.xmin) : a.xmin.compareTo(b.xmin);
-    }
-    return a.ymin.compareTo(b.ymin);
+    final band = bands[a]!.compareTo(bands[b]!);
+    if (band != 0) return band;
+    final x = readingX(a).compareTo(readingX(b));
+    if (x != 0) return x;
+    final y = a.ymin.compareTo(b.ymin);
+    if (y != 0) return y;
+    return a.xmin.compareTo(b.xmin);
   });
   return blocks;
 }
+
+/// Assigns every block a row-band index, computed once.
+///
+/// Blocks are swept top-to-bottom and greedily clustered into bands. A block
+/// joins the current band when its vertical extent overlaps the band's running
+/// vertical extent by more than [_bandOverlap]; otherwise it opens a new band.
+/// The running extent is intersected (not unioned) as members are added so a
+/// tall outlier cannot chain unrelated rows together. The returned map is keyed
+/// by block identity, giving each block a stable integer index in reading order
+/// of rows (top-most band == 0).
+Map<OcrTextBlock, int> _rowBands(List<OcrTextBlock> blocks) {
+  final ordered = [...blocks]
+    ..sort((a, b) {
+      final y = a.ymin.compareTo(b.ymin);
+      if (y != 0) return y;
+      return a.ymax.compareTo(b.ymax);
+    });
+  final result = <OcrTextBlock, int>{};
+  var band = -1;
+  var bandMin = 0.0;
+  var bandMax = 0.0;
+  for (final block in ordered) {
+    if (band < 0 ||
+        _overlap(bandMin, bandMax, block.ymin, block.ymax) <= _bandOverlap) {
+      band++;
+      bandMin = block.ymin;
+      bandMax = block.ymax;
+    } else {
+      bandMin = math.max(bandMin, block.ymin);
+      bandMax = math.min(bandMax, block.ymax);
+    }
+    result[block] = band;
+  }
+  return result;
+}
+
+/// Minimum vertical overlap fraction for two blocks to share a reading row.
+const double _bandOverlap = 0.2;
 
 String _clean(String value) =>
     value.replaceAll(RegExp(r'[\r\n\t]+'), '').trim();

--- a/test/services/mining/ocr_block_merger_test.dart
+++ b/test/services/mining/ocr_block_merger_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mangayomi/services/mining/ocr_block_merger.dart';
 import 'package:mangayomi/services/mining/ocr_models.dart';
@@ -129,6 +131,144 @@ void main() {
     // Boxes far outside the close radius must not be merged.
     expect(merged, hasLength(2));
   });
+
+  // Regression suite for issue #34: the cross-box Japanese reading order must
+  // be a mathematically valid total ordering. PR #79's comparator mixed an
+  // overlap-conditional axis flip (compare on x when two boxes shared a row,
+  // else on y), which is not transitive and mis-ordered multi-row grids. These
+  // tests pin the full expected order for a grid, the original staggered-bubble
+  // case, and determinism under shuffling.
+  group('issue #34 reading order (valid total ordering)', () {
+    test('orders a >=6-box multi-row Japanese layout the old comparator '
+        'mis-sorted', () {
+      // Six separated blocks (they survive paragraph/close-group merging as
+      // distinct blocks, so the reading-order comparator is exercised on all
+      // six). This is the multi-row adversarial layout PR #79's
+      // overlap-conditional comparator got wrong: its non-transitive relation
+      // produced order [B4, B0, B2, B1, B5, B3] — B1 (y=0.672..0.917) sorted
+      // ahead of the higher B5 (y=0.610..0.688). The banded total ordering
+      // reads top band to bottom band, right-to-left within each band, giving
+      // the correct [B4, B0, B2, B5, B3, B1].
+      List<OcrTextBlock> layout() => [
+        _sep('B0', 0.843, 0.096, 0.976, 0.414),
+        _sep('B1', 0.164, 0.672, 0.268, 0.917),
+        _sep('B2', 0.381, 0.476, 0.522, 0.645),
+        _sep('B3', 0.749, 0.703, 0.858, 0.895),
+        _sep('B4', 0.788, 0.011, 0.919, 0.096),
+        _sep('B5', 0.006, 0.610, 0.091, 0.688),
+      ];
+
+      final merged = mergeOcrBlocks(layout(), language: 'ja');
+
+      expect(merged.map((block) => block.lines.single).toList(), [
+        'B4',
+        'B0',
+        'B2',
+        'B5',
+        'B3',
+        'B1',
+      ]);
+    });
+
+    test('orders a clean 3-column x 2-row Japanese grid right-to-left', () {
+      // A textbook clean grid: two well-separated rows of three columns each.
+      // Japanese reads each row right-to-left, top row before bottom row.
+      final blocks = [
+        _sep('r1c1', 0.05, 0.05, 0.20, 0.15),
+        _sep('r1c2', 0.42, 0.05, 0.57, 0.15),
+        _sep('r1c3', 0.80, 0.05, 0.95, 0.15),
+        _sep('r2c1', 0.05, 0.55, 0.20, 0.65),
+        _sep('r2c2', 0.42, 0.55, 0.57, 0.65),
+        _sep('r2c3', 0.80, 0.55, 0.95, 0.65),
+      ];
+
+      final merged = mergeOcrBlocks(blocks, language: 'ja');
+
+      expect(merged.map((block) => block.lines.single).toList(), [
+        'r1c3',
+        'r1c2',
+        'r1c1',
+        'r2c3',
+        'r2c2',
+        'r2c1',
+      ]);
+    });
+
+    test('orders two staggered Japanese bubbles right-to-left', () {
+      // The original narrow two-bubble fixture PR #79 was built around: two
+      // vertically-staggered bubbles that still share the same reading row, so
+      // the right one is read first under right-to-left Japanese order.
+      final blocks = [
+        _sep('left', 0.05, 0.12, 0.25, 0.30),
+        _sep('right', 0.60, 0.08, 0.80, 0.26),
+      ];
+
+      final merged = mergeOcrBlocks(blocks, language: 'ja');
+
+      expect(merged.map((block) => block.lines.single).toList(), [
+        'right',
+        'left',
+      ]);
+    });
+
+    test('sorting is deterministic and consistent under shuffled input', () {
+      // Three separated blocks whose vertical extents form the exact
+      // non-transitive triple that PR #79's overlap-flip comparator mis-sorts:
+      // P0/P1 share a row band while P2 does not overlap P0, so the old
+      // pairwise relation had cmp(P0,P1)<0, cmp(P1,P2)<0 but cmp(P0,P2)>0 — a
+      // cycle. Fed to List.sort that yields input-order-dependent output. The
+      // banded key is a valid total ordering, so every permutation must yield
+      // the identical reading order.
+      List<OcrTextBlock> triple() => [
+        _sep('P0', 0.583, 0.507, 0.678, 0.907),
+        _sep('P1', 0.347, 0.481, 0.537, 0.592),
+        _sep('P2', 0.701, 0.692, 0.807, 0.748),
+      ];
+
+      List<String> order(List<OcrTextBlock> blocks) => mergeOcrBlocks(
+        blocks,
+        language: 'ja',
+      ).map((block) => block.lines.single).toList();
+
+      // The fixture must reach reading order as three distinct blocks (not
+      // merged) for this to exercise the comparator.
+      expect(order(triple()), hasLength(3));
+
+      // Full expected reading order: P0 and P1 share the upper band (read
+      // right-to-left: P0 then P1), P2 is the lower band.
+      const expected = ['P0', 'P1', 'P2'];
+      expect(order(triple()), expected);
+
+      // Deterministic across many shuffles — no dependence on input order.
+      final random = Random(1234);
+      for (var i = 0; i < 100; i++) {
+        expect(order(triple()..shuffle(random)), expected);
+      }
+
+      // Idempotent: sorting the produced order again is a fixed point.
+      expect(order(mergeOcrBlocks(triple(), language: 'ja')), expected);
+    });
+
+    test('left-to-right (non-Japanese) grid reads rows left-to-right', () {
+      final blocks = [
+        _sep('r1c1', 0.05, 0.05, 0.20, 0.15),
+        _sep('r1c2', 0.42, 0.05, 0.57, 0.15),
+        _sep('r1c3', 0.80, 0.05, 0.95, 0.15),
+        _sep('r2c1', 0.05, 0.55, 0.20, 0.65),
+        _sep('r2c2', 0.42, 0.55, 0.57, 0.65),
+      ];
+
+      final merged = mergeOcrBlocks(blocks, language: 'en');
+
+      expect(merged.map((block) => block.lines.single).toList(), [
+        'r1c1',
+        'r1c2',
+        'r1c3',
+        'r2c1',
+        'r2c2',
+      ]);
+    });
+  });
 }
 
 OcrTextBlock _block(
@@ -152,6 +292,35 @@ OcrTextBlock _block(
     ymax: bottom,
     lines: [text],
     vertical: vertical,
+    lineGeometries: [geometry],
+    language: 'ja',
+  );
+}
+
+/// A single separated (non-merging) block for reading-order tests.
+///
+/// Reading order runs on the blocks that survive paragraph/close-group
+/// merging, so these fixtures are spaced far enough apart to stay distinct and
+/// exercise the comparator directly on every box.
+OcrTextBlock _sep(
+  String text,
+  double left,
+  double top,
+  double right,
+  double bottom,
+) {
+  final geometry = OcrLineGeometry(
+    xmin: left,
+    ymin: top,
+    xmax: right,
+    ymax: bottom,
+  );
+  return OcrTextBlock(
+    xmin: left,
+    ymin: top,
+    xmax: right,
+    ymax: bottom,
+    lines: [text],
     lineGeometries: [geometry],
     language: 'ja',
   );


### PR DESCRIPTION
Refs #34

## Problem

PR #79 was closed by the maintainer: its cross-box reading-order comparator "is not a valid total ordering and regresses multi-row Japanese layouts. A focused test passed, but the broader grid case demonstrated incorrect ordering."

The old comparator in `_readingOrder` compared each pair conditionally on their vertical overlap:

```dart
final overlap = _overlap(a.ymin, a.ymax, b.ymin, b.ymax);
if (overlap > 0.2) return japanese ? b.xmin.compareTo(a.xmin) : a.xmin.compareTo(b.xmin); // x axis
return a.ymin.compareTo(b.ymin);                                                          // y axis
```

This axis flip makes the relation **non-transitive**. For three boxes A, B, C where A/B share a row and B/C share a row but A/C do not, the pairwise decisions are computed on different axes and can form a cycle (e.g. `cmp(A,B)<0`, `cmp(B,C)<0`, `cmp(A,C)>0`). Feeding a non-transitive comparator to `List.sort` yields input-order-dependent, incorrect output — the multi-row grid regression the maintainer observed. A brute-force search over random layouts confirms the cycle is real, not hypothetical.

## Fix — a valid total ordering

Instead of pairwise axis flips, reading rows ("bands") are computed **once** up front, then blocks are sorted by a fixed lexicographic key that is a pure function of each block:

1. `_rowBands` sweeps blocks top-to-bottom and greedily clusters them into row bands by vertical-extent overlap, assigning every block a single integer band index. The running band extent is **intersected** (not unioned) as members are added, so one tall outlier can't chain unrelated rows together.
2. `_readingOrder` sorts by the key `(bandIndex, reading-x, ymin, xmin)`, where `reading-x` runs right-to-left for vertical Japanese (`-xmin`) and left-to-right otherwise (`+xmin`). The `ymin`/`xmin` tie-breakers make it a strict order.

Because the sort key depends only on each block (never on the pair being compared), the comparator is **antisymmetric and transitive** — a mathematically valid total ordering — and therefore **deterministic**: any permutation of the input yields the same reading order.

### How it handles the maintainer's grid case

For a multi-row grid, banding assigns each visual row a distinct index in top-to-bottom order, and within a band boxes read right-to-left (Japanese) by their own x. There is no cross-row axis flip to create a cycle, so a >=6-box grid is ordered row-by-row correctly and stably, regardless of the order the OCR engine emitted the boxes.

## Tests

`test/services/mining/ocr_block_merger_test.dart` adds a regression group:

- **>=6-box multi-row layout** the old comparator mis-sorted — asserts the full expected order `[B4,B0,B2,B5,B3,B1]`. Reverting to the old comparator makes this test fail with `[B4,B0,B2,B1,B5,B3]` (verified), so it genuinely guards the fix.
- **clean 3x2 grid** — full expected right-to-left, top-to-bottom order.
- **two staggered bubbles** — the original narrow fixture, right-to-left.
- **determinism / consistency** — a non-transitive triple sorted 100x under shuffled input yields the identical order; sorting the result again is a fixed point.
- **left-to-right (non-Japanese) grid** — confirms the LTR path.

Scope is limited to `ocr_block_merger.dart` + its test. PR #86 (spacing) and PR #88 (sentence continuity) behavior is preserved.

## Verification

- `dart format --set-exit-if-changed` on both touched files — clean.
- `flutter analyze` on both touched files — no issues.
- `flutter test test/services/mining/` — 147 pass. The 2 failures (`animated_avif_validator_test`, `desktop_scene_capture_test`) are pre-existing environment failures that shell out to `ffmpeg`; they don't reference the changed file.
- `git diff --check` — clean.

This does not close the issue.
