### PR TITLE
test(anki): pin issue #36 scalable-screenshot crop workflow

### DIFF
--- a/lib/modules/mining/widgets/hoshi_dictionary_popup.dart
+++ b/lib/modules/mining/widgets/hoshi_dictionary_popup.dart
@@ -1430,13 +1430,38 @@ class _HoshiPopupData {
   final String html;
 }
 
+/// Default crop window seeded by the screenshot crop dialog and restored by the
+/// free/square aspect presets: a centered 80% rectangle of the source panel.
+///
+/// Issue #36 ("[Feature request] Scalable screenshot") asked for exporting an
+/// adjustable single-panel region instead of the whole page. Seeding the crop
+/// to a sub-rect (not `0..1`) is what makes the default export smaller than the
+/// full page; a regression to a full-page default would silently re-export the
+/// whole page.
+const Rect kAnkiCropDefaultRect = Rect.fromLTRB(0.1, 0.1, 0.9, 0.9);
+
+/// Renders the region currently selected on [controller] to PNG bytes — the
+/// exact step the crop dialog's "Crop" button performs before the manually
+/// cropped panel is handed back to the Anki export via
+/// [MiningContext.imageBytesLoader].
+///
+/// The output pixel dimensions are the chosen crop rect scaled by the source
+/// bitmap (`crop.width * image.width` x `crop.height * image.height` for an
+/// unrotated panel), so the exported image is the user's chosen sub-rect, not
+/// the full captured page. Returns `null` when the raster produced no bytes.
+Future<Uint8List?> cropControllerToPngBytes(CropController controller) async {
+  final ui.Image bitmap = await controller.croppedBitmap();
+  final byteData = await bitmap.toByteData(format: ui.ImageByteFormat.png);
+  return byteData?.buffer.asUint8List();
+}
+
 Future<Uint8List?> _showCropDialog({
   required BuildContext context,
   required Uint8List imageBytes,
 }) async {
   final controller = CropController(
     aspectRatio: null, // Free crop by default
-    defaultCrop: const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9),
+    defaultCrop: kAnkiCropDefaultRect,
   );
 
   final theme = Theme.of(context);
@@ -1459,13 +1484,10 @@ Future<Uint8List?> _showCropDialog({
           Future<void> handleCrop() async {
             setState(() => cropping = true);
             try {
-              final ui.Image bitmap = await controller.croppedBitmap();
-              final byteData = await bitmap.toByteData(
-                format: ui.ImageByteFormat.png,
-              );
+              final bytes = await cropControllerToPngBytes(controller);
               if (!context.mounted) return;
-              if (byteData != null) {
-                Navigator.pop(context, byteData.buffer.asUint8List());
+              if (bytes != null) {
+                Navigator.pop(context, bytes);
               } else {
                 botToast('Could not crop image: empty result', second: 4);
                 setState(() => cropping = false);
@@ -1533,12 +1555,7 @@ Future<Uint8List?> _showCropDialog({
                               selected: aspectMode == _CropAspectMode.free,
                               onPressed: () {
                                 controller.aspectRatio = null;
-                                controller.crop = const Rect.fromLTRB(
-                                  0.1,
-                                  0.1,
-                                  0.9,
-                                  0.9,
-                                );
+                                controller.crop = kAnkiCropDefaultRect;
                                 setState(
                                   () => aspectMode = _CropAspectMode.free,
                                 );
@@ -1551,12 +1568,7 @@ Future<Uint8List?> _showCropDialog({
                               selected: aspectMode == _CropAspectMode.square,
                               onPressed: () {
                                 controller.aspectRatio = 1.0;
-                                controller.crop = const Rect.fromLTRB(
-                                  0.1,
-                                  0.1,
-                                  0.9,
-                                  0.9,
-                                );
+                                controller.crop = kAnkiCropDefaultRect;
                                 setState(
                                   () => aspectMode = _CropAspectMode.square,
                                 );
@@ -1650,12 +1662,7 @@ class _CropToolbarState extends State<_CropToolbar> {
               selected: _mode == _CropAspectMode.free,
               onPressed: () {
                 widget.controller.aspectRatio = null;
-                widget.controller.crop = const Rect.fromLTRB(
-                  0.1,
-                  0.1,
-                  0.9,
-                  0.9,
-                );
+                widget.controller.crop = kAnkiCropDefaultRect;
                 setState(() => _mode = _CropAspectMode.free);
               },
             ),
@@ -1666,12 +1673,7 @@ class _CropToolbarState extends State<_CropToolbar> {
               selected: _mode == _CropAspectMode.square,
               onPressed: () {
                 widget.controller.aspectRatio = 1.0;
-                widget.controller.crop = const Rect.fromLTRB(
-                  0.1,
-                  0.1,
-                  0.9,
-                  0.9,
-                );
+                widget.controller.crop = kAnkiCropDefaultRect;
                 setState(() => _mode = _CropAspectMode.square);
               },
             ),
@@ -1715,11 +1717,10 @@ class _CropActionsRowState extends State<_CropActionsRow> {
   Future<void> _handleCrop() async {
     setState(() => _cropping = true);
     try {
-      final ui.Image bitmap = await widget.controller.croppedBitmap();
-      final byteData = await bitmap.toByteData(format: ui.ImageByteFormat.png);
+      final bytes = await cropControllerToPngBytes(widget.controller);
       if (!mounted) return;
-      if (byteData != null) {
-        Navigator.pop(context, byteData.buffer.asUint8List());
+      if (bytes != null) {
+        Navigator.pop(context, bytes);
         return;
       }
       botToast('Could not crop image: empty result', second: 4);

--- a/test/modules/mining/anki_screenshot_crop_test.dart
+++ b/test/modules/mining/anki_screenshot_crop_test.dart
@@ -1,0 +1,145 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:crop_image/crop_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/mining/widgets/hoshi_dictionary_popup.dart';
+
+/// Paints a solid [width]x[height] bitmap so the crop workflow operates on a
+/// real image whose pixel dimensions we can reason about deterministically.
+Future<ui.Image> _solidImage(int width, int height) async {
+  final recorder = ui.PictureRecorder();
+  final canvas = Canvas(recorder);
+  canvas.drawRect(
+    Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+    Paint()..color = const Color(0xFF3366CC),
+  );
+  return recorder.endRecording().toImage(width, height);
+}
+
+/// Decodes PNG bytes back into a [ui.Image] so we can assert exported pixel
+/// dimensions.
+Future<ui.Image> _decode(Uint8List bytes) async {
+  final codec = await ui.instantiateImageCodec(bytes);
+  final frame = await codec.getNextFrame();
+  return frame.image;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Issue #36 ("[Feature request] Scalable screenshot") asked for the ability
+  // to screenshot a single manga panel with adjustable dimensions before Anki
+  // export, instead of always exporting the whole page. The user-facing
+  // workflow is the "Crop Screenshot" dialog in hoshi_dictionary_popup.dart:
+  // when AnkiScreenshotMode.crop is selected the dialog wraps
+  // MiningContext.imageBytesLoader, the user drags/resizes/rotates the crop
+  // rect on a CropController, and pressing "Crop" turns the *chosen sub-rect*
+  // into the PNG bytes that land on the Anki card.
+  //
+  // `cropControllerToPngBytes` is that exact production step (the dialog's
+  // handleCrop / _CropActionsRow._handleCrop both call it), and
+  // `kAnkiCropDefaultRect` is the sub-rect the dialog seeds and its aspect
+  // presets reset to. PR #83 was rejected for asserting generic
+  // screenshot-loader behavior instead of this crop mapping; these tests pin
+  // the crop-rect -> exported-bytes contract the feature actually depends on.
+  group('issue #36 crop workflow: crop-rect -> exported PNG bytes', () {
+    testWidgets('exports exactly the manually chosen sub-rect of the panel', (
+      tester,
+    ) async {
+      late ui.Image exported;
+      await tester.runAsync(() async {
+        // Source panel: a tall manga page 200x300.
+        final controller = CropController();
+        controller.image = await _solidImage(200, 300);
+
+        // User drags/resizes the crop rect to the middle-left half of the page:
+        //   x: 0.25 -> 0.75  (width 0.50)
+        //   y: 0.50 -> 1.00  (height 0.50)
+        controller.crop = const Rect.fromLTRB(0.25, 0.5, 0.75, 1.0);
+
+        final bytes = await cropControllerToPngBytes(controller);
+        expect(bytes, isNotNull);
+        exported = await _decode(bytes!);
+        controller.dispose();
+      });
+
+      // 0.50 * 200 = 100 wide, 0.50 * 300 = 150 tall — the chosen sub-rect,
+      // NOT the full 200x300 page.
+      expect(exported.width, 100);
+      expect(exported.height, 150);
+    });
+
+    testWidgets(
+      'the default crop window exports a proportionally smaller panel, '
+      'not the full page',
+      (tester) async {
+        late ui.Image exported;
+        await tester.runAsync(() async {
+          // Seeded with the dialog's real default rect (kAnkiCropDefaultRect,
+          // the centered 80% window) and accepted untouched.
+          final controller = CropController(
+            aspectRatio: null,
+            defaultCrop: kAnkiCropDefaultRect,
+          );
+          controller.image = await _solidImage(400, 200);
+          final bytes = await cropControllerToPngBytes(controller);
+          expect(bytes, isNotNull);
+          exported = await _decode(bytes!);
+          controller.dispose();
+        });
+
+        // 0.8 * 400 = 320, 0.8 * 200 = 160 — strictly smaller than the source,
+        // proving the crop rect (not the full page) drives the export.
+        expect(exported.width, 320);
+        expect(exported.height, 160);
+        expect(exported.width, lessThan(400));
+        expect(exported.height, lessThan(200));
+      },
+    );
+
+    testWidgets(
+      'distinct crop rects produce distinctly sized exports (rect-proportional)',
+      (tester) async {
+        // Paired case so the exported dimensions track the chosen rect, not a
+        // fixed constant: a narrow crop and a wide crop of the same 1000x1000
+        // source must yield different, rect-proportional outputs.
+        late ui.Image narrow;
+        late ui.Image wide;
+        await tester.runAsync(() async {
+          final c1 = CropController();
+          c1.image = await _solidImage(1000, 1000);
+          c1.crop = const Rect.fromLTRB(0.0, 0.0, 0.1, 0.2); // 100x200
+          narrow = await _decode((await cropControllerToPngBytes(c1))!);
+          c1.dispose();
+
+          final c2 = CropController();
+          c2.image = await _solidImage(1000, 1000);
+          c2.crop = const Rect.fromLTRB(0.0, 0.0, 0.9, 0.3); // 900x300
+          wide = await _decode((await cropControllerToPngBytes(c2))!);
+          c2.dispose();
+        });
+
+        expect(narrow.width, 100);
+        expect(narrow.height, 200);
+        expect(wide.width, 900);
+        expect(wide.height, 300);
+      },
+    );
+
+    test(
+      'the default crop window is the centered 80% sub-rect (never the full page)',
+      () {
+        // Guards the constant the dialog seeds and its aspect presets reset to.
+        // A regression to a full-page 0..1 default would silently re-export the
+        // whole page — exactly the behavior issue #36 asked to replace.
+        expect(kAnkiCropDefaultRect, const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9));
+        expect(kAnkiCropDefaultRect.width, closeTo(0.8, 1e-9));
+        expect(kAnkiCropDefaultRect.height, closeTo(0.8, 1e-9));
+        expect(kAnkiCropDefaultRect.left, greaterThan(0.0));
+        expect(kAnkiCropDefaultRect.right, lessThan(1.0));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Refs #36. Supersedes closed PR #83.

## Why PR #83 was rejected
The maintainer closed #83 with: "The tests are green, but they exercise generic screenshot-loader behavior rather than the crop dialog/workflow requested by issue #36. They therefore do not genuinely protect the scalable-screenshot feature."

## What this PR protects
Issue #36 ("[Feature request] Scalable screenshot") asked for exporting an **adjustable single manga panel** before Anki export instead of the whole page. The user-facing implementation is the "Crop Screenshot" dialog in `hoshi_dictionary_popup.dart`: when `AnkiScreenshotMode.crop` is selected, the dialog wraps `MiningContext.imageBytesLoader`, the user drags/resizes/rotates the crop rect on a `CropController`, and pressing **Crop** rasters the *chosen sub-rect* to the PNG bytes that land on the card.

These tests pin the actual crop workflow — the **crop-rect → exported-bytes** contract — not generic loader behavior:

- exports exactly the manually chosen sub-rect (0.25..0.75 × 0.5..1.0 of a 200×300 page → 100×150), not the full page;
- the seeded default window exports a proportionally smaller panel (80% → 320×160 of 400×200), strictly `< source`;
- distinct crop rects produce distinctly sized, rect-proportional exports (paired negative case: narrow 100×200 vs wide 900×300 of the same 1000×1000 source);
- the default crop window is the centered 80% sub-rect and never a full-page 0..1 default.

## Production change (minimal, behavior-preserving)
Extracted the dialog's rasterization step into a named production helper `cropControllerToPngBytes(CropController)` and the seeded window into `kAnkiCropDefaultRect`, then routed both crop paths (`_showCropDialog.handleCrop` and `_CropActionsRow._handleCrop`) and every aspect-preset reset through them. No behavior change — this only gives the regression tests a real production symbol to assert against (the private inline dialog was previously untestable).

## Proof the tests guard the behavior (RED→GREEN)
Temporarily forcing the crop to the full `0..1` rect before rastering fails 3/4 tests (`+1 -3`); restoring the production helper passes 4/4 with the production file at zero diff vs the committed change.

## Verification
- `dart format` clean; `flutter analyze` No issues found
- `flutter test test/modules/mining/anki_screenshot_crop_test.dart` → 4/4
- `flutter test test/services/m_extension_server_test.dart` (AGENTS.md gate) → 4/4
- `git diff --check` clean
- No pubspec build bump (test + non-native-runtime change, not a device-testable IPA change).